### PR TITLE
FillBounds property and startedLoading callback

### DIFF
--- a/Classes/YTPlayerView.h
+++ b/Classes/YTPlayerView.h
@@ -59,6 +59,13 @@ typedef enum {
 
 @optional
 /**
+ * Invoked when the player view starts loading its contents but not necessarily buffering.
+ *
+ * @param playerView The YTPlayerView instance that has started loading.
+ */
+- (void)playerStartedLoading:(YTPlayerView *)playerView;
+
+/**
  * Invoked when the player view is ready to receive API calls.
  *
  * @param playerView The YTPlayerView instance that has become ready.
@@ -100,6 +107,9 @@ typedef enum {
 @interface YTPlayerView : UIView<UIWebViewDelegate>
 
 @property(nonatomic, strong, readonly) UIWebView *webView;
+
+/** Tells the player to adapt to the full height and width of the view. Will only have effect the next time a video is loaded. */
+@property(nonatomic, getter = shouldFillBounds) BOOL fillBounds;
 
 /** A delegate to be notified on playback events. */
 @property(nonatomic, weak) id<YTPlayerViewDelegate> delegate;

--- a/Classes/YTPlayerView.h
+++ b/Classes/YTPlayerView.h
@@ -43,7 +43,7 @@ typedef enum {
     kYTPlayerErrorInvalidParam,
     kYTPlayerErrorHTML5Error,
     kYTPlayerErrorVideoNotFound, // Functionally equivalent error codes 100 and
-    // 105 have been collapsed into |kYTPlayerErrorVideoNotFound|.
+                                 // 105 have been collapsed into |kYTPlayerErrorVideoNotFound|.
     kYTPlayerErrorNotEmbeddable,
     kYTPlayerErrorUnknown
 } YTPlayerError;
@@ -58,6 +58,13 @@ typedef enum {
 @protocol YTPlayerViewDelegate<NSObject>
 
 @optional
+/**
+ * Invoked when the player view starts loading its contents but not necessarily buffering.
+ *
+ * @param playerView The YTPlayerView instance that has started loading.
+ */
+- (void)playerStartedLoading:(YTPlayerView *)playerView;
+
 /**
  * Invoked when the player view is ready to receive API calls.
  *
@@ -100,6 +107,9 @@ typedef enum {
 @interface YTPlayerView : UIView<UIWebViewDelegate>
 
 @property(nonatomic, strong, readonly) UIWebView *webView;
+
+/** Tells the player to adapt to the full height and width of the view. Will only have effect the next time a video is loaded. */
+@property(nonatomic, getter = shouldFillBounds) BOOL fillBounds;
 
 /** A delegate to be notified on playback events. */
 @property(nonatomic, weak) id<YTPlayerViewDelegate> delegate;

--- a/Classes/YTPlayerView.h
+++ b/Classes/YTPlayerView.h
@@ -43,7 +43,7 @@ typedef enum {
     kYTPlayerErrorInvalidParam,
     kYTPlayerErrorHTML5Error,
     kYTPlayerErrorVideoNotFound, // Functionally equivalent error codes 100 and
-                                 // 105 have been collapsed into |kYTPlayerErrorVideoNotFound|.
+    // 105 have been collapsed into |kYTPlayerErrorVideoNotFound|.
     kYTPlayerErrorNotEmbeddable,
     kYTPlayerErrorUnknown
 } YTPlayerError;
@@ -58,13 +58,6 @@ typedef enum {
 @protocol YTPlayerViewDelegate<NSObject>
 
 @optional
-/**
- * Invoked when the player view starts loading its contents but not necessarily buffering.
- *
- * @param playerView The YTPlayerView instance that has started loading.
- */
-- (void)playerStartedLoading:(YTPlayerView *)playerView;
-
 /**
  * Invoked when the player view is ready to receive API calls.
  *
@@ -107,9 +100,6 @@ typedef enum {
 @interface YTPlayerView : UIView<UIWebViewDelegate>
 
 @property(nonatomic, strong, readonly) UIWebView *webView;
-
-/** Tells the player to adapt to the full height and width of the view. Will only have effect the next time a video is loaded. */
-@property(nonatomic, getter = shouldFillBounds) BOOL fillBounds;
 
 /** A delegate to be notified on playback events. */
 @property(nonatomic, weak) id<YTPlayerViewDelegate> delegate;

--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -55,57 +55,61 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
 @implementation YTPlayerView
 
 - (BOOL)loadWithVideoId:(NSString *)videoId {
-  return [self loadWithVideoId:videoId playerVars:nil];
+    return [self loadWithVideoId:videoId playerVars:nil];
 }
 
 - (BOOL)loadWithPlaylistId:(NSString *)playlistId {
-  return [self loadWithPlaylistId:playlistId playerVars:nil];
+    return [self loadWithPlaylistId:playlistId playerVars:nil];
 }
 
 - (BOOL)loadWithVideoId:(NSString *)videoId playerVars:(NSDictionary *)playerVars {
-  if (!playerVars) {
-    playerVars = @{};
-  }
-  NSDictionary *playerParams = @{ @"videoId" : videoId, @"playerVars" : playerVars };
-  return [self loadWithPlayerParams:playerParams];
+    if (!playerVars) {
+        playerVars = @{};
+    }
+    NSDictionary *playerParams = @{ @"videoId" : videoId, @"playerVars" : playerVars };
+    return [self loadWithPlayerParams:playerParams];
 }
 
 - (BOOL)loadWithPlaylistId:(NSString *)playlistId playerVars:(NSDictionary *)playerVars {
-
-  // Mutable copy because we may have been passed an immutable config dictionary.
-  NSMutableDictionary *tempPlayerVars = [[NSMutableDictionary alloc] init];
-  [tempPlayerVars setValue:@"playlist" forKey:@"listType"];
-  [tempPlayerVars setValue:playlistId forKey:@"list"];
-  [tempPlayerVars addEntriesFromDictionary:playerVars];  // No-op if playerVars is null
-
-  NSDictionary *playerParams = @{ @"playerVars" : tempPlayerVars };
-  return [self loadWithPlayerParams:playerParams];
+    
+    // Mutable copy because we may have been passed an immutable config dictionary.
+    NSMutableDictionary *tempPlayerVars = [[NSMutableDictionary alloc] init];
+    [tempPlayerVars setValue:@"playlist" forKey:@"listType"];
+    [tempPlayerVars setValue:playlistId forKey:@"list"];
+    [tempPlayerVars addEntriesFromDictionary:playerVars];  // No-op if playerVars is null
+    
+    NSDictionary *playerParams = @{ @"playerVars" : tempPlayerVars };
+    return [self loadWithPlayerParams:playerParams];
 }
 
 #pragma mark - Player methods
 
 - (void)playVideo {
-  [self stringFromEvaluatingJavaScript:@"player.playVideo();"];
+    [self stringFromEvaluatingJavaScript:@"player.playVideo();"];
 }
 
 - (void)pauseVideo {
-  [self stringFromEvaluatingJavaScript:@"player.pauseVideo();"];
+    [self stringFromEvaluatingJavaScript:@"player.pauseVideo();"];
 }
 
 - (void)stopVideo {
-  [self stringFromEvaluatingJavaScript:@"player.stopVideo();"];
+    [self stringFromEvaluatingJavaScript:@"player.stopVideo();"];
 }
 
 - (void)seekToSeconds:(float)seekToSeconds allowSeekAhead:(BOOL)allowSeekAhead {
-  NSNumber *secondsValue = [NSNumber numberWithFloat:seekToSeconds];
-  NSString *allowSeekAheadValue = [self stringForJSBoolean:allowSeekAhead];
-  NSString *command =
-      [NSString stringWithFormat:@"player.seekTo(%@, %@);", secondsValue, allowSeekAheadValue];
-  [self stringFromEvaluatingJavaScript:command];
+    NSNumber *secondsValue = [NSNumber numberWithFloat:seekToSeconds];
+    NSString *allowSeekAheadValue = [self stringForJSBoolean:allowSeekAhead];
+    NSString *command =
+    [NSString stringWithFormat:@"player.seekTo(%@, %@);", secondsValue, allowSeekAheadValue];
+    [self stringFromEvaluatingJavaScript:command];
 }
 
 - (void)clearVideo {
-  [self stringFromEvaluatingJavaScript:@"player.clearVideo();"];
+    [self stringFromEvaluatingJavaScript:@"player.clearVideo();"];
+}
+
+- (void)setFillBounds:(BOOL)fillBounds {
+    _fillBounds = fillBounds;
 }
 
 #pragma mark - Cueing methods
@@ -113,89 +117,89 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
 - (void)cueVideoById:(NSString *)videoId
         startSeconds:(float)startSeconds
     suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-  NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
-  NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
-  NSString *command = [NSString stringWithFormat:@"player.cueVideoById('%@', %@, '%@');",
-      videoId, startSecondsValue, qualityValue];
-  [self stringFromEvaluatingJavaScript:command];
+    NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
+    NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
+    NSString *command = [NSString stringWithFormat:@"player.cueVideoById('%@', %@, '%@');",
+                         videoId, startSecondsValue, qualityValue];
+    [self stringFromEvaluatingJavaScript:command];
 }
 
 - (void)cueVideoById:(NSString *)videoId
         startSeconds:(float)startSeconds
           endSeconds:(float)endSeconds
     suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-  NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
-  NSNumber *endSecondsValue = [NSNumber numberWithFloat:endSeconds];
-  NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
-  NSString *command = [NSString stringWithFormat:@"player.cueVideoById('%@', %@, %@, '%@');",
-      videoId, startSecondsValue, endSecondsValue, qualityValue];
-  [self stringFromEvaluatingJavaScript:command];
+    NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
+    NSNumber *endSecondsValue = [NSNumber numberWithFloat:endSeconds];
+    NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
+    NSString *command = [NSString stringWithFormat:@"player.cueVideoById('%@', %@, %@, '%@');",
+                         videoId, startSecondsValue, endSecondsValue, qualityValue];
+    [self stringFromEvaluatingJavaScript:command];
 }
 
 - (void)loadVideoById:(NSString *)videoId
          startSeconds:(float)startSeconds
      suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-  NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
-  NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
-  NSString *command = [NSString stringWithFormat:@"player.loadVideoById('%@', %@, '%@');",
-      videoId, startSecondsValue, qualityValue];
-  [self stringFromEvaluatingJavaScript:command];
+    NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
+    NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
+    NSString *command = [NSString stringWithFormat:@"player.loadVideoById('%@', %@, '%@');",
+                         videoId, startSecondsValue, qualityValue];
+    [self stringFromEvaluatingJavaScript:command];
 }
 
 - (void)loadVideoById:(NSString *)videoId
          startSeconds:(float)startSeconds
            endSeconds:(float)endSeconds
      suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-  NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
-  NSNumber *endSecondsValue = [NSNumber numberWithFloat:endSeconds];
-  NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
-  NSString *command = [NSString stringWithFormat:@"player.loadVideoById('%@', %@, %@, '%@');",
-      videoId, startSecondsValue, endSecondsValue, qualityValue];
-  [self stringFromEvaluatingJavaScript:command];
+    NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
+    NSNumber *endSecondsValue = [NSNumber numberWithFloat:endSeconds];
+    NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
+    NSString *command = [NSString stringWithFormat:@"player.loadVideoById('%@', %@, %@, '%@');",
+                         videoId, startSecondsValue, endSecondsValue, qualityValue];
+    [self stringFromEvaluatingJavaScript:command];
 }
 
 - (void)cueVideoByURL:(NSString *)videoURL
          startSeconds:(float)startSeconds
      suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-  NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
-  NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
-  NSString *command = [NSString stringWithFormat:@"player.cueVideoByUrl('%@', %@, '%@');",
-      videoURL, startSecondsValue, qualityValue];
-  [self stringFromEvaluatingJavaScript:command];
+    NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
+    NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
+    NSString *command = [NSString stringWithFormat:@"player.cueVideoByUrl('%@', %@, '%@');",
+                         videoURL, startSecondsValue, qualityValue];
+    [self stringFromEvaluatingJavaScript:command];
 }
 
 - (void)cueVideoByURL:(NSString *)videoURL
          startSeconds:(float)startSeconds
            endSeconds:(float)endSeconds
      suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-  NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
-  NSNumber *endSecondsValue = [NSNumber numberWithFloat:endSeconds];
-  NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
-  NSString *command = [NSString stringWithFormat:@"player.cueVideoByUrl('%@', %@, %@, '%@');",
-      videoURL, startSecondsValue, endSecondsValue, qualityValue];
-  [self stringFromEvaluatingJavaScript:command];
+    NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
+    NSNumber *endSecondsValue = [NSNumber numberWithFloat:endSeconds];
+    NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
+    NSString *command = [NSString stringWithFormat:@"player.cueVideoByUrl('%@', %@, %@, '%@');",
+                         videoURL, startSecondsValue, endSecondsValue, qualityValue];
+    [self stringFromEvaluatingJavaScript:command];
 }
 
 - (void)loadVideoByURL:(NSString *)videoURL
           startSeconds:(float)startSeconds
       suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-  NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
-  NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
-  NSString *command = [NSString stringWithFormat:@"player.loadVideoByUrl('%@', %@, '%@');",
-      videoURL, startSecondsValue, qualityValue];
-  [self stringFromEvaluatingJavaScript:command];
+    NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
+    NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
+    NSString *command = [NSString stringWithFormat:@"player.loadVideoByUrl('%@', %@, '%@');",
+                         videoURL, startSecondsValue, qualityValue];
+    [self stringFromEvaluatingJavaScript:command];
 }
 
 - (void)loadVideoByURL:(NSString *)videoURL
           startSeconds:(float)startSeconds
             endSeconds:(float)endSeconds
       suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-  NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
-  NSNumber *endSecondsValue = [NSNumber numberWithFloat:endSeconds];
-  NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
-  NSString *command = [NSString stringWithFormat:@"player.loadVideoByUrl('%@', %@, %@, '%@');",
-      videoURL, startSecondsValue, endSecondsValue, qualityValue];
-  [self stringFromEvaluatingJavaScript:command];
+    NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
+    NSNumber *endSecondsValue = [NSNumber numberWithFloat:endSeconds];
+    NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
+    NSString *command = [NSString stringWithFormat:@"player.loadVideoByUrl('%@', %@, %@, '%@');",
+                         videoURL, startSecondsValue, endSecondsValue, qualityValue];
+    [self stringFromEvaluatingJavaScript:command];
 }
 
 #pragma mark - Cueing methods for lists
@@ -204,29 +208,29 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
                           index:(int)index
                    startSeconds:(float)startSeconds
                suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-  NSString *playlistIdString = [NSString stringWithFormat:@"'%@'", playlistId];
-  [self cuePlaylist:playlistIdString
-                 index:index
-          startSeconds:startSeconds
-      suggestedQuality:suggestedQuality];
+    NSString *playlistIdString = [NSString stringWithFormat:@"'%@'", playlistId];
+    [self cuePlaylist:playlistIdString
+                index:index
+         startSeconds:startSeconds
+     suggestedQuality:suggestedQuality];
 }
 
 - (void)cuePlaylistByVideos:(NSArray *)videoIds
                       index:(int)index
                startSeconds:(float)startSeconds
            suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-  [self cuePlaylist:[self stringFromVideoIdArray:videoIds]
-                 index:index
-          startSeconds:startSeconds
-      suggestedQuality:suggestedQuality];
+    [self cuePlaylist:[self stringFromVideoIdArray:videoIds]
+                index:index
+         startSeconds:startSeconds
+     suggestedQuality:suggestedQuality];
 }
 
 - (void)loadPlaylistByPlaylistId:(NSString *)playlistId
                            index:(int)index
                     startSeconds:(float)startSeconds
                 suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-  NSString *playlistIdString = [NSString stringWithFormat:@"'%@'", playlistId];
-  [self loadPlaylist:playlistIdString
+    NSString *playlistIdString = [NSString stringWithFormat:@"'%@'", playlistId];
+    [self loadPlaylist:playlistIdString
                  index:index
           startSeconds:startSeconds
       suggestedQuality:suggestedQuality];
@@ -236,7 +240,7 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
                        index:(int)index
                 startSeconds:(float)startSeconds
             suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-  [self loadPlaylist:[self stringFromVideoIdArray:videoIds]
+    [self loadPlaylist:[self stringFromVideoIdArray:videoIds]
                  index:index
           startSeconds:startSeconds
       suggestedQuality:suggestedQuality];
@@ -245,158 +249,164 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
 #pragma mark - Setting the playback rate
 
 - (float)playbackRate {
-  NSString *returnValue = [self stringFromEvaluatingJavaScript:@"player.getPlaybackRate();"];
-  return [returnValue floatValue];
+    NSString *returnValue = [self stringFromEvaluatingJavaScript:@"player.getPlaybackRate();"];
+    return [returnValue floatValue];
 }
 
 - (void)setPlaybackRate:(float)suggestedRate {
-  NSString *command = [NSString stringWithFormat:@"player.setPlaybackRate(%f);", suggestedRate];
-  [self stringFromEvaluatingJavaScript:command];
+    NSString *command = [NSString stringWithFormat:@"player.setPlaybackRate(%f);", suggestedRate];
+    [self stringFromEvaluatingJavaScript:command];
 }
 
 - (NSArray *)availablePlaybackRates {
-  NSString *returnValue =
-      [self stringFromEvaluatingJavaScript:@"player.getAvailablePlaybackRates();"];
-
-  NSData *playbackRateData = [returnValue dataUsingEncoding:NSUTF8StringEncoding];
-  NSError *jsonDeserializationError;
-  NSArray *playbackRates = [NSJSONSerialization JSONObjectWithData:playbackRateData
-                                                           options:kNilOptions
-                                                             error:&jsonDeserializationError];
-  if (jsonDeserializationError) {
-    return nil;
-  }
-
-  return playbackRates;
+    NSString *returnValue =
+    [self stringFromEvaluatingJavaScript:@"player.getAvailablePlaybackRates();"];
+    
+    NSData *playbackRateData = [returnValue dataUsingEncoding:NSUTF8StringEncoding];
+    NSError *jsonDeserializationError;
+    NSArray *playbackRates = [NSJSONSerialization JSONObjectWithData:playbackRateData
+                                                             options:kNilOptions
+                                                               error:&jsonDeserializationError];
+    if (jsonDeserializationError) {
+        return nil;
+    }
+    
+    return playbackRates;
 }
 
 #pragma mark - Setting playback behavior for playlists
 
 - (void)setLoop:(BOOL)loop {
-  NSString *loopPlayListValue = [self stringForJSBoolean:loop];
-  NSString *command = [NSString stringWithFormat:@"player.setLoop(%@);", loopPlayListValue];
-  [self stringFromEvaluatingJavaScript:command];
+    NSString *loopPlayListValue = [self stringForJSBoolean:loop];
+    NSString *command = [NSString stringWithFormat:@"player.setLoop(%@);", loopPlayListValue];
+    [self stringFromEvaluatingJavaScript:command];
 }
 
 - (void)setShuffle:(BOOL)shuffle {
-  NSString *shufflePlayListValue = [self stringForJSBoolean:shuffle];
-  NSString *command = [NSString stringWithFormat:@"player.setShuffle(%@);", shufflePlayListValue];
-  [self stringFromEvaluatingJavaScript:command];
+    NSString *shufflePlayListValue = [self stringForJSBoolean:shuffle];
+    NSString *command = [NSString stringWithFormat:@"player.setShuffle(%@);", shufflePlayListValue];
+    [self stringFromEvaluatingJavaScript:command];
 }
 
 #pragma mark - Playback status
 
 - (float)videoLoadedFraction {
-  return [[self stringFromEvaluatingJavaScript:@"player.getVideoLoadedFraction();"] floatValue];
+    return [[self stringFromEvaluatingJavaScript:@"player.getVideoLoadedFraction();"] floatValue];
 }
 
 - (YTPlayerState)playerState {
-  NSString *returnValue = [self stringFromEvaluatingJavaScript:@"player.getPlayerState();"];
-  return [YTPlayerView playerStateForString:returnValue];
+    NSString *returnValue = [self stringFromEvaluatingJavaScript:@"player.getPlayerState();"];
+    return [YTPlayerView playerStateForString:returnValue];
 }
 
 - (float)currentTime {
-  return [[self stringFromEvaluatingJavaScript:@"player.getCurrentTime();"] floatValue];
+    return [[self stringFromEvaluatingJavaScript:@"player.getCurrentTime();"] floatValue];
 }
 
 // Playback quality
 - (YTPlaybackQuality)playbackQuality {
-  NSString *qualityValue = [self stringFromEvaluatingJavaScript:@"player.getPlaybackQuality();"];
-  return [YTPlayerView playbackQualityForString:qualityValue];
+    NSString *qualityValue = [self stringFromEvaluatingJavaScript:@"player.getPlaybackQuality();"];
+    return [YTPlayerView playbackQualityForString:qualityValue];
 }
 
 - (void)setPlaybackQuality:(YTPlaybackQuality)suggestedQuality {
-  NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
-  NSString *command = [NSString stringWithFormat:@"player.setPlaybackQuality('%@');", qualityValue];
-  [self stringFromEvaluatingJavaScript:command];
+    NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
+    NSString *command = [NSString stringWithFormat:@"player.setPlaybackQuality('%@');", qualityValue];
+    [self stringFromEvaluatingJavaScript:command];
 }
 
 #pragma mark - Video information methods
 
 - (int)duration {
-  return [[self stringFromEvaluatingJavaScript:@"player.getDuration();"] intValue];
+    return [[self stringFromEvaluatingJavaScript:@"player.getDuration();"] intValue];
 }
 
 - (NSURL *)videoUrl {
-  return [NSURL URLWithString:[self stringFromEvaluatingJavaScript:@"player.getVideoUrl();"]];
+    return [NSURL URLWithString:[self stringFromEvaluatingJavaScript:@"player.getVideoUrl();"]];
 }
 
 - (NSString *)videoEmbedCode {
-  return [self stringFromEvaluatingJavaScript:@"player.getVideoEmbedCode();"];
+    return [self stringFromEvaluatingJavaScript:@"player.getVideoEmbedCode();"];
 }
 
 #pragma mark - Playlist methods
 
 - (NSArray *)playlist {
-  NSString *returnValue = [self stringFromEvaluatingJavaScript:@"player.getPlaylist();"];
-
-  NSData *playlistData = [returnValue dataUsingEncoding:NSUTF8StringEncoding];
-  NSError *jsonDeserializationError;
-  NSArray *videoIds = [NSJSONSerialization JSONObjectWithData:playlistData
-                                                      options:kNilOptions
-                                                        error:&jsonDeserializationError];
-  if (jsonDeserializationError) {
-    return nil;
-  }
-
-  return videoIds;
+    NSString *returnValue = [self stringFromEvaluatingJavaScript:@"player.getPlaylist();"];
+    
+    NSData *playlistData = [returnValue dataUsingEncoding:NSUTF8StringEncoding];
+    NSError *jsonDeserializationError;
+    NSArray *videoIds = [NSJSONSerialization JSONObjectWithData:playlistData
+                                                        options:kNilOptions
+                                                          error:&jsonDeserializationError];
+    if (jsonDeserializationError) {
+        return nil;
+    }
+    
+    return videoIds;
 }
 
 - (int)playlistIndex {
-  NSString *returnValue = [self stringFromEvaluatingJavaScript:@"player.getPlaylistIndex();"];
-  return [returnValue intValue];
+    NSString *returnValue = [self stringFromEvaluatingJavaScript:@"player.getPlaylistIndex();"];
+    return [returnValue intValue];
 }
 
 #pragma mark - Playing a video in a playlist
 
 - (void)nextVideo {
-  [self stringFromEvaluatingJavaScript:@"player.nextVideo();"];
+    [self stringFromEvaluatingJavaScript:@"player.nextVideo();"];
 }
 
 - (void)previousVideo {
-  [self stringFromEvaluatingJavaScript:@"player.previousVideo();"];
+    [self stringFromEvaluatingJavaScript:@"player.previousVideo();"];
 }
 
 - (void)playVideoAt:(int)index {
-  NSString *command =
-      [NSString stringWithFormat:@"player.playVideoAt(%@);", [NSNumber numberWithInt:index]];
-  [self stringFromEvaluatingJavaScript:command];
+    NSString *command =
+    [NSString stringWithFormat:@"player.playVideoAt(%@);", [NSNumber numberWithInt:index]];
+    [self stringFromEvaluatingJavaScript:command];
 }
 
 #pragma mark - Helper methods
 
 - (NSArray *)availableQualityLevels {
-  NSString *returnValue =
-      [self stringFromEvaluatingJavaScript:@"player.getAvailableQualityLevels();"];
-
-  NSData *availableQualityLevelsData = [returnValue dataUsingEncoding:NSUTF8StringEncoding];
-  NSError *jsonDeserializationError;
-
-  NSArray *rawQualityValues = [NSJSONSerialization JSONObjectWithData:availableQualityLevelsData
-                                                              options:kNilOptions
-                                                                error:&jsonDeserializationError];
-  if (jsonDeserializationError) {
-    return nil;
-  }
-
-  NSMutableArray *levels = [[NSMutableArray alloc] init];
-  for (NSString *rawQualityValue in rawQualityValues) {
-    YTPlaybackQuality quality = [YTPlayerView playbackQualityForString:rawQualityValue];
-    [levels addObject:[NSNumber numberWithInt:quality]];
-  }
-  return levels;
+    NSString *returnValue =
+    [self stringFromEvaluatingJavaScript:@"player.getAvailableQualityLevels();"];
+    
+    NSData *availableQualityLevelsData = [returnValue dataUsingEncoding:NSUTF8StringEncoding];
+    NSError *jsonDeserializationError;
+    
+    NSArray *rawQualityValues = [NSJSONSerialization JSONObjectWithData:availableQualityLevelsData
+                                                                options:kNilOptions
+                                                                  error:&jsonDeserializationError];
+    if (jsonDeserializationError) {
+        return nil;
+    }
+    
+    NSMutableArray *levels = [[NSMutableArray alloc] init];
+    for (NSString *rawQualityValue in rawQualityValues) {
+        YTPlaybackQuality quality = [YTPlayerView playbackQualityForString:rawQualityValue];
+        [levels addObject:[NSNumber numberWithInt:quality]];
+    }
+    return levels;
 }
 
 - (BOOL)webView:(UIWebView *)webView
-    shouldStartLoadWithRequest:(NSURLRequest *)request
-                navigationType:(UIWebViewNavigationType)navigationType {
-  if ([request.URL.scheme isEqual:@"ytplayer"]) {
-    [self notifyDelegateOfYouTubeCallbackUrl:request.URL];
-    return NO;
-  } else if ([request.URL.scheme isEqual: @"http"] || [request.URL.scheme isEqual:@"https"]) {
-    return [self handleHttpNavigationToUrl:request.URL];
-  }
-  return YES;
+shouldStartLoadWithRequest:(NSURLRequest *)request
+ navigationType:(UIWebViewNavigationType)navigationType {
+    if ([request.URL.scheme isEqual:@"ytplayer"]) {
+        [self notifyDelegateOfYouTubeCallbackUrl:request.URL];
+        return NO;
+    } else if ([request.URL.scheme isEqual: @"http"] || [request.URL.scheme isEqual:@"https"]) {
+        return [self handleHttpNavigationToUrl:request.URL];
+    }
+    return YES;
+}
+
+- (void)webViewDidStartLoad:(UIWebView *)webView {
+    if ([self.delegate respondsToSelector:@selector(playerStartedLoading:)]) {
+        [self.delegate playerStartedLoading:self];
+    }
 }
 
 /**
@@ -406,23 +416,23 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
  * @return An enum value representing the playback quality.
  */
 + (YTPlaybackQuality)playbackQualityForString:(NSString *)qualityString {
-  YTPlaybackQuality quality = kYTPlaybackQualityUnknown;
-
-  if ([qualityString isEqualToString:kYTPlaybackQualitySmallQuality]) {
-    quality = kYTPlaybackQualitySmall;
-  } else if ([qualityString isEqualToString:kYTPlaybackQualityMediumQuality]) {
-    quality = kYTPlaybackQualityMedium;
-  } else if ([qualityString isEqualToString:kYTPlaybackQualityLargeQuality]) {
-    quality = kYTPlaybackQualityLarge;
-  } else if ([qualityString isEqualToString:kYTPlaybackQualityHD720Quality]) {
-    quality = kYTPlaybackQualityHD720;
-  } else if ([qualityString isEqualToString:kYTPlaybackQualityHD1080Quality]) {
-    quality = kYTPlaybackQualityHD1080;
-  } else if ([qualityString isEqualToString:kYTPlaybackQualityHighResQuality]) {
-    quality = kYTPlaybackQualityHighRes;
-  }
-
-  return quality;
+    YTPlaybackQuality quality = kYTPlaybackQualityUnknown;
+    
+    if ([qualityString isEqualToString:kYTPlaybackQualitySmallQuality]) {
+        quality = kYTPlaybackQualitySmall;
+    } else if ([qualityString isEqualToString:kYTPlaybackQualityMediumQuality]) {
+        quality = kYTPlaybackQualityMedium;
+    } else if ([qualityString isEqualToString:kYTPlaybackQualityLargeQuality]) {
+        quality = kYTPlaybackQualityLarge;
+    } else if ([qualityString isEqualToString:kYTPlaybackQualityHD720Quality]) {
+        quality = kYTPlaybackQualityHD720;
+    } else if ([qualityString isEqualToString:kYTPlaybackQualityHD1080Quality]) {
+        quality = kYTPlaybackQualityHD1080;
+    } else if ([qualityString isEqualToString:kYTPlaybackQualityHighResQuality]) {
+        quality = kYTPlaybackQualityHighRes;
+    }
+    
+    return quality;
 }
 
 /**
@@ -432,22 +442,22 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
  * @return An |NSString| value to be used in the JavaScript bridge.
  */
 + (NSString *)stringForPlaybackQuality:(YTPlaybackQuality)quality {
-  switch (quality) {
-    case kYTPlaybackQualitySmall:
-      return kYTPlaybackQualitySmallQuality;
-    case kYTPlaybackQualityMedium:
-      return kYTPlaybackQualityMediumQuality;
-    case kYTPlaybackQualityLarge:
-      return kYTPlaybackQualityLargeQuality;
-    case kYTPlaybackQualityHD720:
-      return kYTPlaybackQualityHD720Quality;
-    case kYTPlaybackQualityHD1080:
-      return kYTPlaybackQualityHD1080Quality;
-    case kYTPlaybackQualityHighRes:
-      return kYTPlaybackQualityHighResQuality;
-    default:
-      return kYTPlaybackQualityUnknownQuality;
-  }
+    switch (quality) {
+        case kYTPlaybackQualitySmall:
+            return kYTPlaybackQualitySmallQuality;
+        case kYTPlaybackQualityMedium:
+            return kYTPlaybackQualityMediumQuality;
+        case kYTPlaybackQualityLarge:
+            return kYTPlaybackQualityLargeQuality;
+        case kYTPlaybackQualityHD720:
+            return kYTPlaybackQualityHD720Quality;
+        case kYTPlaybackQualityHD1080:
+            return kYTPlaybackQualityHD1080Quality;
+        case kYTPlaybackQualityHighRes:
+            return kYTPlaybackQualityHighResQuality;
+        default:
+            return kYTPlaybackQualityUnknownQuality;
+    }
 }
 
 /**
@@ -457,21 +467,21 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
  * @return An enum value representing the player state.
  */
 + (YTPlayerState)playerStateForString:(NSString *)stateString {
-  YTPlayerState state = kYTPlayerStateUnknown;
-  if ([stateString isEqualToString:kYTPlayerStateUnstartedCode]) {
-    state = kYTPlayerStateUnstarted;
-  } else if ([stateString isEqualToString:kYTPlayerStateEndedCode]) {
-    state = kYTPlayerStateEnded;
-  } else if ([stateString isEqualToString:kYTPlayerStatePlayingCode]) {
-    state = kYTPlayerStatePlaying;
-  } else if ([stateString isEqualToString:kYTPlayerStatePausedCode]) {
-    state = kYTPlayerStatePaused;
-  } else if ([stateString isEqualToString:kYTPlayerStateBufferingCode]) {
-    state = kYTPlayerStateBuffering;
-  } else if ([stateString isEqualToString:kYTPlayerStateCuedCode]) {
-    state = kYTPlayerStateQueued;
-  }
-  return state;
+    YTPlayerState state = kYTPlayerStateUnknown;
+    if ([stateString isEqualToString:kYTPlayerStateUnstartedCode]) {
+        state = kYTPlayerStateUnstarted;
+    } else if ([stateString isEqualToString:kYTPlayerStateEndedCode]) {
+        state = kYTPlayerStateEnded;
+    } else if ([stateString isEqualToString:kYTPlayerStatePlayingCode]) {
+        state = kYTPlayerStatePlaying;
+    } else if ([stateString isEqualToString:kYTPlayerStatePausedCode]) {
+        state = kYTPlayerStatePaused;
+    } else if ([stateString isEqualToString:kYTPlayerStateBufferingCode]) {
+        state = kYTPlayerStateBuffering;
+    } else if ([stateString isEqualToString:kYTPlayerStateCuedCode]) {
+        state = kYTPlayerStateQueued;
+    }
+    return state;
 }
 
 /**
@@ -481,22 +491,22 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
  * @return A string value to be used in the JavaScript bridge.
  */
 + (NSString *)stringForPlayerState:(YTPlayerState)state {
-  switch (state) {
-    case kYTPlayerStateUnstarted:
-      return kYTPlayerStateUnstartedCode;
-    case kYTPlayerStateEnded:
-      return kYTPlayerStateEndedCode;
-    case kYTPlayerStatePlaying:
-      return kYTPlayerStatePlayingCode;
-    case kYTPlayerStatePaused:
-      return kYTPlayerStatePausedCode;
-    case kYTPlayerStateBuffering:
-      return kYTPlayerStateBufferingCode;
-    case kYTPlayerStateQueued:
-      return kYTPlayerStateCuedCode;
-    default:
-      return kYTPlayerStateUnknownCode;
-  }
+    switch (state) {
+        case kYTPlayerStateUnstarted:
+            return kYTPlayerStateUnstartedCode;
+        case kYTPlayerStateEnded:
+            return kYTPlayerStateEndedCode;
+        case kYTPlayerStatePlaying:
+            return kYTPlayerStatePlayingCode;
+        case kYTPlayerStatePaused:
+            return kYTPlayerStatePausedCode;
+        case kYTPlayerStateBuffering:
+            return kYTPlayerStateBufferingCode;
+        case kYTPlayerStateQueued:
+            return kYTPlayerStateCuedCode;
+        default:
+            return kYTPlayerStateUnknownCode;
+    }
 }
 
 #pragma mark - Private methods
@@ -510,85 +520,85 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
  * @param url A URL of the format http://ytplayer/action.
  */
 - (void)notifyDelegateOfYouTubeCallbackUrl: (NSURL *) url {
-  NSString *action = url.host;
-
-  // We know the query can only be of the format http://ytplayer?data=SOMEVALUE,
-  // so we parse out the value.
-  NSString *query = url.query;
-  NSString *data;
-  if (query) {
-    data = [query componentsSeparatedByString:@"="][1];
-  }
-
-  if ([action isEqual:kYTPlayerCallbackOnReady]) {
-    if ([self.delegate respondsToSelector:@selector(playerViewDidBecomeReady:)]) {
-      [self.delegate playerViewDidBecomeReady:self];
+    NSString *action = url.host;
+    
+    // We know the query can only be of the format http://ytplayer?data=SOMEVALUE,
+    // so we parse out the value.
+    NSString *query = url.query;
+    NSString *data;
+    if (query) {
+        data = [query componentsSeparatedByString:@"="][1];
     }
-  } else if ([action isEqual:kYTPlayerCallbackOnStateChange]) {
-    if ([self.delegate respondsToSelector:@selector(playerView:didChangeToState:)]) {
-      YTPlayerState state = kYTPlayerStateUnknown;
-
-      if ([data isEqual:kYTPlayerStateEndedCode]) {
-        state = kYTPlayerStateEnded;
-      } else if ([data isEqual:kYTPlayerStatePlayingCode]) {
-        state = kYTPlayerStatePlaying;
-      } else if ([data isEqual:kYTPlayerStatePausedCode]) {
-        state = kYTPlayerStatePaused;
-      } else if ([data isEqual:kYTPlayerStateBufferingCode]) {
-        state = kYTPlayerStateBuffering;
-      } else if ([data isEqual:kYTPlayerStateCuedCode]) {
-        state = kYTPlayerStateQueued;
-      } else if ([data isEqual:kYTPlayerStateUnstartedCode]) {
-        state = kYTPlayerStateUnstarted;
-      }
-
-      [self.delegate playerView:self didChangeToState:state];
+    
+    if ([action isEqual:kYTPlayerCallbackOnReady]) {
+        if ([self.delegate respondsToSelector:@selector(playerViewDidBecomeReady:)]) {
+            [self.delegate playerViewDidBecomeReady:self];
+        }
+    } else if ([action isEqual:kYTPlayerCallbackOnStateChange]) {
+        if ([self.delegate respondsToSelector:@selector(playerView:didChangeToState:)]) {
+            YTPlayerState state = kYTPlayerStateUnknown;
+            
+            if ([data isEqual:kYTPlayerStateEndedCode]) {
+                state = kYTPlayerStateEnded;
+            } else if ([data isEqual:kYTPlayerStatePlayingCode]) {
+                state = kYTPlayerStatePlaying;
+            } else if ([data isEqual:kYTPlayerStatePausedCode]) {
+                state = kYTPlayerStatePaused;
+            } else if ([data isEqual:kYTPlayerStateBufferingCode]) {
+                state = kYTPlayerStateBuffering;
+            } else if ([data isEqual:kYTPlayerStateCuedCode]) {
+                state = kYTPlayerStateQueued;
+            } else if ([data isEqual:kYTPlayerStateUnstartedCode]) {
+                state = kYTPlayerStateUnstarted;
+            }
+            
+            [self.delegate playerView:self didChangeToState:state];
+        }
+    } else if ([action isEqual:kYTPlayerCallbackOnPlaybackQualityChange]) {
+        if ([self.delegate respondsToSelector:@selector(playerView:didChangeToQuality:)]) {
+            YTPlaybackQuality quality = [YTPlayerView playbackQualityForString:data];
+            [self.delegate playerView:self didChangeToQuality:quality];
+        }
+    } else if ([action isEqual:kYTPlayerCallbackOnError]) {
+        if ([self.delegate respondsToSelector:@selector(playerView:receivedError:)]) {
+            YTPlayerError error = kYTPlayerErrorUnknown;
+            
+            if ([data isEqual:kYTPlayerErrorInvalidParamErrorCode]) {
+                error = kYTPlayerErrorInvalidParam;
+            } else if ([data isEqual:kYTPlayerErrorHTML5ErrorCode]) {
+                error = kYTPlayerErrorHTML5Error;
+            } else if ([data isEqual:kYTPlayerErrorNotEmbeddableErrorCode]) {
+                error = kYTPlayerErrorNotEmbeddable;
+            } else if ([data isEqual:kYTPlayerErrorVideoNotFoundErrorCode] ||
+                       [data isEqual:kYTPlayerErrorCannotFindVideoErrorCode]) {
+                error = kYTPlayerErrorVideoNotFound;
+            }
+            
+            [self.delegate playerView:self receivedError:error];
+        }
     }
-  } else if ([action isEqual:kYTPlayerCallbackOnPlaybackQualityChange]) {
-    if ([self.delegate respondsToSelector:@selector(playerView:didChangeToQuality:)]) {
-      YTPlaybackQuality quality = [YTPlayerView playbackQualityForString:data];
-      [self.delegate playerView:self didChangeToQuality:quality];
-    }
-  } else if ([action isEqual:kYTPlayerCallbackOnError]) {
-    if ([self.delegate respondsToSelector:@selector(playerView:receivedError:)]) {
-      YTPlayerError error = kYTPlayerErrorUnknown;
-
-      if ([data isEqual:kYTPlayerErrorInvalidParamErrorCode]) {
-        error = kYTPlayerErrorInvalidParam;
-      } else if ([data isEqual:kYTPlayerErrorHTML5ErrorCode]) {
-        error = kYTPlayerErrorHTML5Error;
-      } else if ([data isEqual:kYTPlayerErrorNotEmbeddableErrorCode]) {
-        error = kYTPlayerErrorNotEmbeddable;
-      } else if ([data isEqual:kYTPlayerErrorVideoNotFoundErrorCode] ||
-          [data isEqual:kYTPlayerErrorCannotFindVideoErrorCode]) {
-        error = kYTPlayerErrorVideoNotFound;
-      }
-
-      [self.delegate playerView:self receivedError:error];
-    }
-  }
 }
 
 - (BOOL)handleHttpNavigationToUrl:(NSURL *) url {
-  // Usually this means the user has clicked on the YouTube logo or an error message in the
-  // player. Most URLs should open in the browser. The only http(s) URL that should open in this
-  // UIWebView is the URL for the embed, which is of the format:
-  //     http(s)://www.youtube.com/embed/[VIDEO ID]?[PARAMETERS]
-  NSError *error = NULL;
-  NSRegularExpression *regex =
-      [NSRegularExpression regularExpressionWithPattern:kYTPlayerEmbedUrlRegexPattern
-                                                options:NSRegularExpressionCaseInsensitive
-                                                  error:&error];
-  NSTextCheckingResult *match =
-      [regex firstMatchInString:url.absoluteString
-                        options:0
-                          range:NSMakeRange(0, [url.absoluteString length])];
-  if (match) {
-    return YES;
-  } else {
-    [[UIApplication sharedApplication] openURL:url];
-    return NO;
-  }
+    // Usually this means the user has clicked on the YouTube logo or an error message in the
+    // player. Most URLs should open in the browser. The only http(s) URL that should open in this
+    // UIWebView is the URL for the embed, which is of the format:
+    //     http(s)://www.youtube.com/embed/[VIDEO ID]?[PARAMETERS]
+    NSError *error = NULL;
+    NSRegularExpression *regex =
+    [NSRegularExpression regularExpressionWithPattern:kYTPlayerEmbedUrlRegexPattern
+                                              options:NSRegularExpressionCaseInsensitive
+                                                error:&error];
+    NSTextCheckingResult *match =
+    [regex firstMatchInString:url.absoluteString
+                      options:0
+                        range:NSMakeRange(0, [url.absoluteString length])];
+    if (match) {
+        return YES;
+    } else {
+        [[UIApplication sharedApplication] openURL:url];
+        return NO;
+    }
 }
 
 
@@ -601,61 +611,73 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
  * @return YES if successful, NO if not.
  */
 - (BOOL)loadWithPlayerParams:(NSDictionary *)additionalPlayerParams {
-  NSDictionary *playerCallbacks = @{
-        @"onReady" : @"onReady",
-        @"onStateChange" : @"onStateChange",
-        @"onPlaybackQualityChange" : @"onPlaybackQualityChange",
-        @"onError" : @"onPlayerError"
-  };
-  NSMutableDictionary *playerParams = [[NSMutableDictionary alloc] init];
-  [playerParams addEntriesFromDictionary:additionalPlayerParams];
-  [playerParams setValue:@"100%" forKey:@"height"];
-  [playerParams setValue:@"100%" forKey:@"width"];
-  [playerParams setValue:playerCallbacks forKey:@"events"];
-
-  // This must not be empty so we can render a '{}' in the output JSON
-  if (![playerParams objectForKey:@"playerVars"]) {
-    [playerParams setValue:[[NSDictionary alloc] init] forKey:@"playerVars"];
-  }
-
-  // Remove the existing webView to reset any state
-  [self.webView removeFromSuperview];
-  _webView = [self createNewWebView];
-  [self addSubview:self.webView];
-
-  NSError *error = nil;
-  NSString *path = [[NSBundle mainBundle] pathForResource:@"YTPlayerView-iframe-player"
-                                                   ofType:@"html"
-                                              inDirectory:@"Assets"];
-  NSString *embedHTMLTemplate =
-      [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:&error];
-
-  if (error) {
-    NSLog(@"Received error rendering template: %@", error);
-    return NO;
-  }
-
-  // Render the playerVars as a JSON dictionary.
-  NSError *jsonRenderingError = nil;
-  NSData *jsonData = [NSJSONSerialization dataWithJSONObject:playerParams
-                                                     options:NSJSONWritingPrettyPrinted
-                                                       error:&jsonRenderingError];
-  if (jsonRenderingError) {
-    NSLog(@"Attempted configuration of player with invalid playerVars: %@ \tError: %@",
-          playerParams,
-          jsonRenderingError);
-    return NO;
-  }
-
-  NSString *playerVarsJsonString =
-      [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-
-  NSString *embedHTML = [NSString stringWithFormat:embedHTMLTemplate, playerVarsJsonString];
-  [self.webView loadHTMLString:embedHTML baseURL:[NSURL URLWithString:@"about:blank"]];
-  [self.webView setDelegate:self];
-  self.webView.allowsInlineMediaPlayback = YES;
-  self.webView.mediaPlaybackRequiresUserAction = NO;
-  return YES;
+    NSDictionary *playerCallbacks = @{
+                                      @"onReady" : @"onReady",
+                                      @"onStateChange" : @"onStateChange",
+                                      @"onPlaybackQualityChange" : @"onPlaybackQualityChange",
+                                      @"onError" : @"onPlayerError"
+                                      };
+    
+    //100% makes the player fit its bounds without losing its aspect. Video never loses aspect though.
+    //By setting the height to the view limits the player will the view completely.
+    NSString *heightString;
+    NSString *widthString;
+    if (self.shouldFillBounds) {
+        heightString = [NSString stringWithFormat:@"%.0f", self.bounds.size.height];
+        widthString = [NSString stringWithFormat:@"%.0f", self.bounds.size.width];
+    }
+    else {
+        heightString = widthString = @"100%";
+    }
+    NSMutableDictionary *playerParams = [[NSMutableDictionary alloc] init];
+    [playerParams addEntriesFromDictionary:additionalPlayerParams];
+    [playerParams setValue:heightString forKey:@"height"];
+    [playerParams setValue:widthString forKey:@"width"];
+    [playerParams setValue:playerCallbacks forKey:@"events"];
+    
+    // This must not be empty so we can render a '{}' in the output JSON
+    if (![playerParams objectForKey:@"playerVars"]) {
+        [playerParams setValue:[[NSDictionary alloc] init] forKey:@"playerVars"];
+    }
+    
+    // Remove the existing webView to reset any state
+    [self.webView removeFromSuperview];
+    _webView = [self createNewWebView];
+    [self addSubview:self.webView];
+    
+    NSError *error = nil;
+    NSString *path = [[NSBundle mainBundle] pathForResource:@"YTPlayerView-iframe-player"
+                                                     ofType:@"html"
+                                                inDirectory:@"Assets"];
+    NSString *embedHTMLTemplate =
+    [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:&error];
+    
+    if (error) {
+        NSLog(@"Received error rendering template: %@", error);
+        return NO;
+    }
+    
+    // Render the playerVars as a JSON dictionary.
+    NSError *jsonRenderingError = nil;
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:playerParams
+                                                       options:NSJSONWritingPrettyPrinted
+                                                         error:&jsonRenderingError];
+    if (jsonRenderingError) {
+        NSLog(@"Attempted configuration of player with invalid playerVars: %@ \tError: %@",
+              playerParams,
+              jsonRenderingError);
+        return NO;
+    }
+    
+    NSString *playerVarsJsonString =
+    [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+    
+    NSString *embedHTML = [NSString stringWithFormat:embedHTMLTemplate, playerVarsJsonString];
+    [self.webView loadHTMLString:embedHTML baseURL:[NSURL URLWithString:@"about:blank"]];
+    [self.webView setDelegate:self];
+    self.webView.allowsInlineMediaPlayback = YES;
+    self.webView.mediaPlaybackRequiresUserAction = NO;
+    return YES;
 }
 
 /**
@@ -670,15 +692,15 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
  * @return The result of cueing the playlist.
  */
 - (void)cuePlaylist:(NSString *)cueingString
-               index:(int)index
-        startSeconds:(float)startSeconds
-    suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-  NSNumber *indexValue = [NSNumber numberWithInt:index];
-  NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
-  NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
-  NSString *command = [NSString stringWithFormat:@"player.cuePlaylist(%@, %@, %@, '%@');",
-      cueingString, indexValue, startSecondsValue, qualityValue];
-  [self stringFromEvaluatingJavaScript:command];
+              index:(int)index
+       startSeconds:(float)startSeconds
+   suggestedQuality:(YTPlaybackQuality)suggestedQuality {
+    NSNumber *indexValue = [NSNumber numberWithInt:index];
+    NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
+    NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
+    NSString *command = [NSString stringWithFormat:@"player.cuePlaylist(%@, %@, %@, '%@');",
+                         cueingString, indexValue, startSecondsValue, qualityValue];
+    [self stringFromEvaluatingJavaScript:command];
 }
 
 /**
@@ -696,12 +718,12 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
                index:(int)index
         startSeconds:(float)startSeconds
     suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-  NSNumber *indexValue = [NSNumber numberWithInt:index];
-  NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
-  NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
-  NSString *command = [NSString stringWithFormat:@"player.loadPlaylist(%@, %@, %@, '%@');",
-      cueingString, indexValue, startSecondsValue, qualityValue];
-  [self stringFromEvaluatingJavaScript:command];
+    NSNumber *indexValue = [NSNumber numberWithInt:index];
+    NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
+    NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
+    NSString *command = [NSString stringWithFormat:@"player.loadPlaylist(%@, %@, %@, '%@');",
+                         cueingString, indexValue, startSecondsValue, qualityValue];
+    [self stringFromEvaluatingJavaScript:command];
 }
 
 /**
@@ -711,13 +733,13 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
  * @return A JavaScript array in String format containing video IDs.
  */
 - (NSString *)stringFromVideoIdArray:(NSArray *)videoIds {
-  NSMutableArray *formattedVideoIds = [[NSMutableArray alloc] init];
-
-  for (id unformattedId in videoIds) {
-    [formattedVideoIds addObject:[NSString stringWithFormat:@"'%@'", unformattedId]];
-  }
-
-  return [NSString stringWithFormat:@"[%@]", [formattedVideoIds componentsJoinedByString:@", "]];
+    NSMutableArray *formattedVideoIds = [[NSMutableArray alloc] init];
+    
+    for (id unformattedId in videoIds) {
+        [formattedVideoIds addObject:[NSString stringWithFormat:@"'%@'", unformattedId]];
+    }
+    
+    return [NSString stringWithFormat:@"[%@]", [formattedVideoIds componentsJoinedByString:@", "]];
 }
 
 /**
@@ -727,7 +749,7 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
  * @return JavaScript response from evaluating code.
  */
 - (NSString *)stringFromEvaluatingJavaScript:(NSString *)jsToExecute {
-  return [self.webView stringByEvaluatingJavaScriptFromString:jsToExecute];
+    return [self.webView stringByEvaluatingJavaScriptFromString:jsToExecute];
 }
 
 /**
@@ -737,20 +759,20 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
  * @return JavaScript Boolean value, i.e. "true" or "false".
  */
 - (NSString *)stringForJSBoolean:(BOOL)boolValue {
-  return boolValue ? @"true" : @"false";
+    return boolValue ? @"true" : @"false";
 }
 
 #pragma mark Exposed for Testing
 - (void)setWebView:(UIWebView *)webView {
-  _webView = webView;
+    _webView = webView;
 }
 
 - (UIWebView *)createNewWebView {
-  UIWebView *webView = [[UIWebView alloc] initWithFrame:self.bounds];
-  webView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
-  webView.scrollView.scrollEnabled = NO;
-  webView.scrollView.bounces = NO;
-  return webView;
+    UIWebView *webView = [[UIWebView alloc] initWithFrame:self.bounds];
+    webView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
+    webView.scrollView.scrollEnabled = NO;
+    webView.scrollView.bounces = NO;
+    return webView;
 }
 
 @end

--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -55,61 +55,57 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
 @implementation YTPlayerView
 
 - (BOOL)loadWithVideoId:(NSString *)videoId {
-    return [self loadWithVideoId:videoId playerVars:nil];
+  return [self loadWithVideoId:videoId playerVars:nil];
 }
 
 - (BOOL)loadWithPlaylistId:(NSString *)playlistId {
-    return [self loadWithPlaylistId:playlistId playerVars:nil];
+  return [self loadWithPlaylistId:playlistId playerVars:nil];
 }
 
 - (BOOL)loadWithVideoId:(NSString *)videoId playerVars:(NSDictionary *)playerVars {
-    if (!playerVars) {
-        playerVars = @{};
-    }
-    NSDictionary *playerParams = @{ @"videoId" : videoId, @"playerVars" : playerVars };
-    return [self loadWithPlayerParams:playerParams];
+  if (!playerVars) {
+    playerVars = @{};
+  }
+  NSDictionary *playerParams = @{ @"videoId" : videoId, @"playerVars" : playerVars };
+  return [self loadWithPlayerParams:playerParams];
 }
 
 - (BOOL)loadWithPlaylistId:(NSString *)playlistId playerVars:(NSDictionary *)playerVars {
-    
-    // Mutable copy because we may have been passed an immutable config dictionary.
-    NSMutableDictionary *tempPlayerVars = [[NSMutableDictionary alloc] init];
-    [tempPlayerVars setValue:@"playlist" forKey:@"listType"];
-    [tempPlayerVars setValue:playlistId forKey:@"list"];
-    [tempPlayerVars addEntriesFromDictionary:playerVars];  // No-op if playerVars is null
-    
-    NSDictionary *playerParams = @{ @"playerVars" : tempPlayerVars };
-    return [self loadWithPlayerParams:playerParams];
+
+  // Mutable copy because we may have been passed an immutable config dictionary.
+  NSMutableDictionary *tempPlayerVars = [[NSMutableDictionary alloc] init];
+  [tempPlayerVars setValue:@"playlist" forKey:@"listType"];
+  [tempPlayerVars setValue:playlistId forKey:@"list"];
+  [tempPlayerVars addEntriesFromDictionary:playerVars];  // No-op if playerVars is null
+
+  NSDictionary *playerParams = @{ @"playerVars" : tempPlayerVars };
+  return [self loadWithPlayerParams:playerParams];
 }
 
 #pragma mark - Player methods
 
 - (void)playVideo {
-    [self stringFromEvaluatingJavaScript:@"player.playVideo();"];
+  [self stringFromEvaluatingJavaScript:@"player.playVideo();"];
 }
 
 - (void)pauseVideo {
-    [self stringFromEvaluatingJavaScript:@"player.pauseVideo();"];
+  [self stringFromEvaluatingJavaScript:@"player.pauseVideo();"];
 }
 
 - (void)stopVideo {
-    [self stringFromEvaluatingJavaScript:@"player.stopVideo();"];
+  [self stringFromEvaluatingJavaScript:@"player.stopVideo();"];
 }
 
 - (void)seekToSeconds:(float)seekToSeconds allowSeekAhead:(BOOL)allowSeekAhead {
-    NSNumber *secondsValue = [NSNumber numberWithFloat:seekToSeconds];
-    NSString *allowSeekAheadValue = [self stringForJSBoolean:allowSeekAhead];
-    NSString *command =
-    [NSString stringWithFormat:@"player.seekTo(%@, %@);", secondsValue, allowSeekAheadValue];
-    [self stringFromEvaluatingJavaScript:command];
+  NSNumber *secondsValue = [NSNumber numberWithFloat:seekToSeconds];
+  NSString *allowSeekAheadValue = [self stringForJSBoolean:allowSeekAhead];
+  NSString *command =
+      [NSString stringWithFormat:@"player.seekTo(%@, %@);", secondsValue, allowSeekAheadValue];
+  [self stringFromEvaluatingJavaScript:command];
 }
 
 - (void)clearVideo {
-    [self stringFromEvaluatingJavaScript:@"player.clearVideo();"];
-}
-
-- (void)setFillBounds:(BOOL)fillBounds {
-    _fillBounds = fillBounds;
+  [self stringFromEvaluatingJavaScript:@"player.clearVideo();"];
 }
 
 #pragma mark - Cueing methods
@@ -117,89 +113,89 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
 - (void)cueVideoById:(NSString *)videoId
         startSeconds:(float)startSeconds
     suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-    NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
-    NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
-    NSString *command = [NSString stringWithFormat:@"player.cueVideoById('%@', %@, '%@');",
-                         videoId, startSecondsValue, qualityValue];
-    [self stringFromEvaluatingJavaScript:command];
+  NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
+  NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
+  NSString *command = [NSString stringWithFormat:@"player.cueVideoById('%@', %@, '%@');",
+      videoId, startSecondsValue, qualityValue];
+  [self stringFromEvaluatingJavaScript:command];
 }
 
 - (void)cueVideoById:(NSString *)videoId
         startSeconds:(float)startSeconds
           endSeconds:(float)endSeconds
     suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-    NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
-    NSNumber *endSecondsValue = [NSNumber numberWithFloat:endSeconds];
-    NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
-    NSString *command = [NSString stringWithFormat:@"player.cueVideoById('%@', %@, %@, '%@');",
-                         videoId, startSecondsValue, endSecondsValue, qualityValue];
-    [self stringFromEvaluatingJavaScript:command];
+  NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
+  NSNumber *endSecondsValue = [NSNumber numberWithFloat:endSeconds];
+  NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
+  NSString *command = [NSString stringWithFormat:@"player.cueVideoById('%@', %@, %@, '%@');",
+      videoId, startSecondsValue, endSecondsValue, qualityValue];
+  [self stringFromEvaluatingJavaScript:command];
 }
 
 - (void)loadVideoById:(NSString *)videoId
          startSeconds:(float)startSeconds
      suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-    NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
-    NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
-    NSString *command = [NSString stringWithFormat:@"player.loadVideoById('%@', %@, '%@');",
-                         videoId, startSecondsValue, qualityValue];
-    [self stringFromEvaluatingJavaScript:command];
+  NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
+  NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
+  NSString *command = [NSString stringWithFormat:@"player.loadVideoById('%@', %@, '%@');",
+      videoId, startSecondsValue, qualityValue];
+  [self stringFromEvaluatingJavaScript:command];
 }
 
 - (void)loadVideoById:(NSString *)videoId
          startSeconds:(float)startSeconds
            endSeconds:(float)endSeconds
      suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-    NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
-    NSNumber *endSecondsValue = [NSNumber numberWithFloat:endSeconds];
-    NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
-    NSString *command = [NSString stringWithFormat:@"player.loadVideoById('%@', %@, %@, '%@');",
-                         videoId, startSecondsValue, endSecondsValue, qualityValue];
-    [self stringFromEvaluatingJavaScript:command];
+  NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
+  NSNumber *endSecondsValue = [NSNumber numberWithFloat:endSeconds];
+  NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
+  NSString *command = [NSString stringWithFormat:@"player.loadVideoById('%@', %@, %@, '%@');",
+      videoId, startSecondsValue, endSecondsValue, qualityValue];
+  [self stringFromEvaluatingJavaScript:command];
 }
 
 - (void)cueVideoByURL:(NSString *)videoURL
          startSeconds:(float)startSeconds
      suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-    NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
-    NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
-    NSString *command = [NSString stringWithFormat:@"player.cueVideoByUrl('%@', %@, '%@');",
-                         videoURL, startSecondsValue, qualityValue];
-    [self stringFromEvaluatingJavaScript:command];
+  NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
+  NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
+  NSString *command = [NSString stringWithFormat:@"player.cueVideoByUrl('%@', %@, '%@');",
+      videoURL, startSecondsValue, qualityValue];
+  [self stringFromEvaluatingJavaScript:command];
 }
 
 - (void)cueVideoByURL:(NSString *)videoURL
          startSeconds:(float)startSeconds
            endSeconds:(float)endSeconds
      suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-    NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
-    NSNumber *endSecondsValue = [NSNumber numberWithFloat:endSeconds];
-    NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
-    NSString *command = [NSString stringWithFormat:@"player.cueVideoByUrl('%@', %@, %@, '%@');",
-                         videoURL, startSecondsValue, endSecondsValue, qualityValue];
-    [self stringFromEvaluatingJavaScript:command];
+  NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
+  NSNumber *endSecondsValue = [NSNumber numberWithFloat:endSeconds];
+  NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
+  NSString *command = [NSString stringWithFormat:@"player.cueVideoByUrl('%@', %@, %@, '%@');",
+      videoURL, startSecondsValue, endSecondsValue, qualityValue];
+  [self stringFromEvaluatingJavaScript:command];
 }
 
 - (void)loadVideoByURL:(NSString *)videoURL
           startSeconds:(float)startSeconds
       suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-    NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
-    NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
-    NSString *command = [NSString stringWithFormat:@"player.loadVideoByUrl('%@', %@, '%@');",
-                         videoURL, startSecondsValue, qualityValue];
-    [self stringFromEvaluatingJavaScript:command];
+  NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
+  NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
+  NSString *command = [NSString stringWithFormat:@"player.loadVideoByUrl('%@', %@, '%@');",
+      videoURL, startSecondsValue, qualityValue];
+  [self stringFromEvaluatingJavaScript:command];
 }
 
 - (void)loadVideoByURL:(NSString *)videoURL
           startSeconds:(float)startSeconds
             endSeconds:(float)endSeconds
       suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-    NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
-    NSNumber *endSecondsValue = [NSNumber numberWithFloat:endSeconds];
-    NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
-    NSString *command = [NSString stringWithFormat:@"player.loadVideoByUrl('%@', %@, %@, '%@');",
-                         videoURL, startSecondsValue, endSecondsValue, qualityValue];
-    [self stringFromEvaluatingJavaScript:command];
+  NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
+  NSNumber *endSecondsValue = [NSNumber numberWithFloat:endSeconds];
+  NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
+  NSString *command = [NSString stringWithFormat:@"player.loadVideoByUrl('%@', %@, %@, '%@');",
+      videoURL, startSecondsValue, endSecondsValue, qualityValue];
+  [self stringFromEvaluatingJavaScript:command];
 }
 
 #pragma mark - Cueing methods for lists
@@ -208,29 +204,29 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
                           index:(int)index
                    startSeconds:(float)startSeconds
                suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-    NSString *playlistIdString = [NSString stringWithFormat:@"'%@'", playlistId];
-    [self cuePlaylist:playlistIdString
-                index:index
-         startSeconds:startSeconds
-     suggestedQuality:suggestedQuality];
+  NSString *playlistIdString = [NSString stringWithFormat:@"'%@'", playlistId];
+  [self cuePlaylist:playlistIdString
+                 index:index
+          startSeconds:startSeconds
+      suggestedQuality:suggestedQuality];
 }
 
 - (void)cuePlaylistByVideos:(NSArray *)videoIds
                       index:(int)index
                startSeconds:(float)startSeconds
            suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-    [self cuePlaylist:[self stringFromVideoIdArray:videoIds]
-                index:index
-         startSeconds:startSeconds
-     suggestedQuality:suggestedQuality];
+  [self cuePlaylist:[self stringFromVideoIdArray:videoIds]
+                 index:index
+          startSeconds:startSeconds
+      suggestedQuality:suggestedQuality];
 }
 
 - (void)loadPlaylistByPlaylistId:(NSString *)playlistId
                            index:(int)index
                     startSeconds:(float)startSeconds
                 suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-    NSString *playlistIdString = [NSString stringWithFormat:@"'%@'", playlistId];
-    [self loadPlaylist:playlistIdString
+  NSString *playlistIdString = [NSString stringWithFormat:@"'%@'", playlistId];
+  [self loadPlaylist:playlistIdString
                  index:index
           startSeconds:startSeconds
       suggestedQuality:suggestedQuality];
@@ -240,7 +236,7 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
                        index:(int)index
                 startSeconds:(float)startSeconds
             suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-    [self loadPlaylist:[self stringFromVideoIdArray:videoIds]
+  [self loadPlaylist:[self stringFromVideoIdArray:videoIds]
                  index:index
           startSeconds:startSeconds
       suggestedQuality:suggestedQuality];
@@ -249,164 +245,158 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
 #pragma mark - Setting the playback rate
 
 - (float)playbackRate {
-    NSString *returnValue = [self stringFromEvaluatingJavaScript:@"player.getPlaybackRate();"];
-    return [returnValue floatValue];
+  NSString *returnValue = [self stringFromEvaluatingJavaScript:@"player.getPlaybackRate();"];
+  return [returnValue floatValue];
 }
 
 - (void)setPlaybackRate:(float)suggestedRate {
-    NSString *command = [NSString stringWithFormat:@"player.setPlaybackRate(%f);", suggestedRate];
-    [self stringFromEvaluatingJavaScript:command];
+  NSString *command = [NSString stringWithFormat:@"player.setPlaybackRate(%f);", suggestedRate];
+  [self stringFromEvaluatingJavaScript:command];
 }
 
 - (NSArray *)availablePlaybackRates {
-    NSString *returnValue =
-    [self stringFromEvaluatingJavaScript:@"player.getAvailablePlaybackRates();"];
-    
-    NSData *playbackRateData = [returnValue dataUsingEncoding:NSUTF8StringEncoding];
-    NSError *jsonDeserializationError;
-    NSArray *playbackRates = [NSJSONSerialization JSONObjectWithData:playbackRateData
-                                                             options:kNilOptions
-                                                               error:&jsonDeserializationError];
-    if (jsonDeserializationError) {
-        return nil;
-    }
-    
-    return playbackRates;
+  NSString *returnValue =
+      [self stringFromEvaluatingJavaScript:@"player.getAvailablePlaybackRates();"];
+
+  NSData *playbackRateData = [returnValue dataUsingEncoding:NSUTF8StringEncoding];
+  NSError *jsonDeserializationError;
+  NSArray *playbackRates = [NSJSONSerialization JSONObjectWithData:playbackRateData
+                                                           options:kNilOptions
+                                                             error:&jsonDeserializationError];
+  if (jsonDeserializationError) {
+    return nil;
+  }
+
+  return playbackRates;
 }
 
 #pragma mark - Setting playback behavior for playlists
 
 - (void)setLoop:(BOOL)loop {
-    NSString *loopPlayListValue = [self stringForJSBoolean:loop];
-    NSString *command = [NSString stringWithFormat:@"player.setLoop(%@);", loopPlayListValue];
-    [self stringFromEvaluatingJavaScript:command];
+  NSString *loopPlayListValue = [self stringForJSBoolean:loop];
+  NSString *command = [NSString stringWithFormat:@"player.setLoop(%@);", loopPlayListValue];
+  [self stringFromEvaluatingJavaScript:command];
 }
 
 - (void)setShuffle:(BOOL)shuffle {
-    NSString *shufflePlayListValue = [self stringForJSBoolean:shuffle];
-    NSString *command = [NSString stringWithFormat:@"player.setShuffle(%@);", shufflePlayListValue];
-    [self stringFromEvaluatingJavaScript:command];
+  NSString *shufflePlayListValue = [self stringForJSBoolean:shuffle];
+  NSString *command = [NSString stringWithFormat:@"player.setShuffle(%@);", shufflePlayListValue];
+  [self stringFromEvaluatingJavaScript:command];
 }
 
 #pragma mark - Playback status
 
 - (float)videoLoadedFraction {
-    return [[self stringFromEvaluatingJavaScript:@"player.getVideoLoadedFraction();"] floatValue];
+  return [[self stringFromEvaluatingJavaScript:@"player.getVideoLoadedFraction();"] floatValue];
 }
 
 - (YTPlayerState)playerState {
-    NSString *returnValue = [self stringFromEvaluatingJavaScript:@"player.getPlayerState();"];
-    return [YTPlayerView playerStateForString:returnValue];
+  NSString *returnValue = [self stringFromEvaluatingJavaScript:@"player.getPlayerState();"];
+  return [YTPlayerView playerStateForString:returnValue];
 }
 
 - (float)currentTime {
-    return [[self stringFromEvaluatingJavaScript:@"player.getCurrentTime();"] floatValue];
+  return [[self stringFromEvaluatingJavaScript:@"player.getCurrentTime();"] floatValue];
 }
 
 // Playback quality
 - (YTPlaybackQuality)playbackQuality {
-    NSString *qualityValue = [self stringFromEvaluatingJavaScript:@"player.getPlaybackQuality();"];
-    return [YTPlayerView playbackQualityForString:qualityValue];
+  NSString *qualityValue = [self stringFromEvaluatingJavaScript:@"player.getPlaybackQuality();"];
+  return [YTPlayerView playbackQualityForString:qualityValue];
 }
 
 - (void)setPlaybackQuality:(YTPlaybackQuality)suggestedQuality {
-    NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
-    NSString *command = [NSString stringWithFormat:@"player.setPlaybackQuality('%@');", qualityValue];
-    [self stringFromEvaluatingJavaScript:command];
+  NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
+  NSString *command = [NSString stringWithFormat:@"player.setPlaybackQuality('%@');", qualityValue];
+  [self stringFromEvaluatingJavaScript:command];
 }
 
 #pragma mark - Video information methods
 
 - (int)duration {
-    return [[self stringFromEvaluatingJavaScript:@"player.getDuration();"] intValue];
+  return [[self stringFromEvaluatingJavaScript:@"player.getDuration();"] intValue];
 }
 
 - (NSURL *)videoUrl {
-    return [NSURL URLWithString:[self stringFromEvaluatingJavaScript:@"player.getVideoUrl();"]];
+  return [NSURL URLWithString:[self stringFromEvaluatingJavaScript:@"player.getVideoUrl();"]];
 }
 
 - (NSString *)videoEmbedCode {
-    return [self stringFromEvaluatingJavaScript:@"player.getVideoEmbedCode();"];
+  return [self stringFromEvaluatingJavaScript:@"player.getVideoEmbedCode();"];
 }
 
 #pragma mark - Playlist methods
 
 - (NSArray *)playlist {
-    NSString *returnValue = [self stringFromEvaluatingJavaScript:@"player.getPlaylist();"];
-    
-    NSData *playlistData = [returnValue dataUsingEncoding:NSUTF8StringEncoding];
-    NSError *jsonDeserializationError;
-    NSArray *videoIds = [NSJSONSerialization JSONObjectWithData:playlistData
-                                                        options:kNilOptions
-                                                          error:&jsonDeserializationError];
-    if (jsonDeserializationError) {
-        return nil;
-    }
-    
-    return videoIds;
+  NSString *returnValue = [self stringFromEvaluatingJavaScript:@"player.getPlaylist();"];
+
+  NSData *playlistData = [returnValue dataUsingEncoding:NSUTF8StringEncoding];
+  NSError *jsonDeserializationError;
+  NSArray *videoIds = [NSJSONSerialization JSONObjectWithData:playlistData
+                                                      options:kNilOptions
+                                                        error:&jsonDeserializationError];
+  if (jsonDeserializationError) {
+    return nil;
+  }
+
+  return videoIds;
 }
 
 - (int)playlistIndex {
-    NSString *returnValue = [self stringFromEvaluatingJavaScript:@"player.getPlaylistIndex();"];
-    return [returnValue intValue];
+  NSString *returnValue = [self stringFromEvaluatingJavaScript:@"player.getPlaylistIndex();"];
+  return [returnValue intValue];
 }
 
 #pragma mark - Playing a video in a playlist
 
 - (void)nextVideo {
-    [self stringFromEvaluatingJavaScript:@"player.nextVideo();"];
+  [self stringFromEvaluatingJavaScript:@"player.nextVideo();"];
 }
 
 - (void)previousVideo {
-    [self stringFromEvaluatingJavaScript:@"player.previousVideo();"];
+  [self stringFromEvaluatingJavaScript:@"player.previousVideo();"];
 }
 
 - (void)playVideoAt:(int)index {
-    NSString *command =
-    [NSString stringWithFormat:@"player.playVideoAt(%@);", [NSNumber numberWithInt:index]];
-    [self stringFromEvaluatingJavaScript:command];
+  NSString *command =
+      [NSString stringWithFormat:@"player.playVideoAt(%@);", [NSNumber numberWithInt:index]];
+  [self stringFromEvaluatingJavaScript:command];
 }
 
 #pragma mark - Helper methods
 
 - (NSArray *)availableQualityLevels {
-    NSString *returnValue =
-    [self stringFromEvaluatingJavaScript:@"player.getAvailableQualityLevels();"];
-    
-    NSData *availableQualityLevelsData = [returnValue dataUsingEncoding:NSUTF8StringEncoding];
-    NSError *jsonDeserializationError;
-    
-    NSArray *rawQualityValues = [NSJSONSerialization JSONObjectWithData:availableQualityLevelsData
-                                                                options:kNilOptions
-                                                                  error:&jsonDeserializationError];
-    if (jsonDeserializationError) {
-        return nil;
-    }
-    
-    NSMutableArray *levels = [[NSMutableArray alloc] init];
-    for (NSString *rawQualityValue in rawQualityValues) {
-        YTPlaybackQuality quality = [YTPlayerView playbackQualityForString:rawQualityValue];
-        [levels addObject:[NSNumber numberWithInt:quality]];
-    }
-    return levels;
+  NSString *returnValue =
+      [self stringFromEvaluatingJavaScript:@"player.getAvailableQualityLevels();"];
+
+  NSData *availableQualityLevelsData = [returnValue dataUsingEncoding:NSUTF8StringEncoding];
+  NSError *jsonDeserializationError;
+
+  NSArray *rawQualityValues = [NSJSONSerialization JSONObjectWithData:availableQualityLevelsData
+                                                              options:kNilOptions
+                                                                error:&jsonDeserializationError];
+  if (jsonDeserializationError) {
+    return nil;
+  }
+
+  NSMutableArray *levels = [[NSMutableArray alloc] init];
+  for (NSString *rawQualityValue in rawQualityValues) {
+    YTPlaybackQuality quality = [YTPlayerView playbackQualityForString:rawQualityValue];
+    [levels addObject:[NSNumber numberWithInt:quality]];
+  }
+  return levels;
 }
 
 - (BOOL)webView:(UIWebView *)webView
-shouldStartLoadWithRequest:(NSURLRequest *)request
- navigationType:(UIWebViewNavigationType)navigationType {
-    if ([request.URL.scheme isEqual:@"ytplayer"]) {
-        [self notifyDelegateOfYouTubeCallbackUrl:request.URL];
-        return NO;
-    } else if ([request.URL.scheme isEqual: @"http"] || [request.URL.scheme isEqual:@"https"]) {
-        return [self handleHttpNavigationToUrl:request.URL];
-    }
-    return YES;
-}
-
-- (void)webViewDidStartLoad:(UIWebView *)webView {
-    if ([self.delegate respondsToSelector:@selector(playerStartedLoading:)]) {
-        [self.delegate playerStartedLoading:self];
-    }
+    shouldStartLoadWithRequest:(NSURLRequest *)request
+                navigationType:(UIWebViewNavigationType)navigationType {
+  if ([request.URL.scheme isEqual:@"ytplayer"]) {
+    [self notifyDelegateOfYouTubeCallbackUrl:request.URL];
+    return NO;
+  } else if ([request.URL.scheme isEqual: @"http"] || [request.URL.scheme isEqual:@"https"]) {
+    return [self handleHttpNavigationToUrl:request.URL];
+  }
+  return YES;
 }
 
 /**
@@ -416,23 +406,23 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
  * @return An enum value representing the playback quality.
  */
 + (YTPlaybackQuality)playbackQualityForString:(NSString *)qualityString {
-    YTPlaybackQuality quality = kYTPlaybackQualityUnknown;
-    
-    if ([qualityString isEqualToString:kYTPlaybackQualitySmallQuality]) {
-        quality = kYTPlaybackQualitySmall;
-    } else if ([qualityString isEqualToString:kYTPlaybackQualityMediumQuality]) {
-        quality = kYTPlaybackQualityMedium;
-    } else if ([qualityString isEqualToString:kYTPlaybackQualityLargeQuality]) {
-        quality = kYTPlaybackQualityLarge;
-    } else if ([qualityString isEqualToString:kYTPlaybackQualityHD720Quality]) {
-        quality = kYTPlaybackQualityHD720;
-    } else if ([qualityString isEqualToString:kYTPlaybackQualityHD1080Quality]) {
-        quality = kYTPlaybackQualityHD1080;
-    } else if ([qualityString isEqualToString:kYTPlaybackQualityHighResQuality]) {
-        quality = kYTPlaybackQualityHighRes;
-    }
-    
-    return quality;
+  YTPlaybackQuality quality = kYTPlaybackQualityUnknown;
+
+  if ([qualityString isEqualToString:kYTPlaybackQualitySmallQuality]) {
+    quality = kYTPlaybackQualitySmall;
+  } else if ([qualityString isEqualToString:kYTPlaybackQualityMediumQuality]) {
+    quality = kYTPlaybackQualityMedium;
+  } else if ([qualityString isEqualToString:kYTPlaybackQualityLargeQuality]) {
+    quality = kYTPlaybackQualityLarge;
+  } else if ([qualityString isEqualToString:kYTPlaybackQualityHD720Quality]) {
+    quality = kYTPlaybackQualityHD720;
+  } else if ([qualityString isEqualToString:kYTPlaybackQualityHD1080Quality]) {
+    quality = kYTPlaybackQualityHD1080;
+  } else if ([qualityString isEqualToString:kYTPlaybackQualityHighResQuality]) {
+    quality = kYTPlaybackQualityHighRes;
+  }
+
+  return quality;
 }
 
 /**
@@ -442,22 +432,22 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
  * @return An |NSString| value to be used in the JavaScript bridge.
  */
 + (NSString *)stringForPlaybackQuality:(YTPlaybackQuality)quality {
-    switch (quality) {
-        case kYTPlaybackQualitySmall:
-            return kYTPlaybackQualitySmallQuality;
-        case kYTPlaybackQualityMedium:
-            return kYTPlaybackQualityMediumQuality;
-        case kYTPlaybackQualityLarge:
-            return kYTPlaybackQualityLargeQuality;
-        case kYTPlaybackQualityHD720:
-            return kYTPlaybackQualityHD720Quality;
-        case kYTPlaybackQualityHD1080:
-            return kYTPlaybackQualityHD1080Quality;
-        case kYTPlaybackQualityHighRes:
-            return kYTPlaybackQualityHighResQuality;
-        default:
-            return kYTPlaybackQualityUnknownQuality;
-    }
+  switch (quality) {
+    case kYTPlaybackQualitySmall:
+      return kYTPlaybackQualitySmallQuality;
+    case kYTPlaybackQualityMedium:
+      return kYTPlaybackQualityMediumQuality;
+    case kYTPlaybackQualityLarge:
+      return kYTPlaybackQualityLargeQuality;
+    case kYTPlaybackQualityHD720:
+      return kYTPlaybackQualityHD720Quality;
+    case kYTPlaybackQualityHD1080:
+      return kYTPlaybackQualityHD1080Quality;
+    case kYTPlaybackQualityHighRes:
+      return kYTPlaybackQualityHighResQuality;
+    default:
+      return kYTPlaybackQualityUnknownQuality;
+  }
 }
 
 /**
@@ -467,21 +457,21 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
  * @return An enum value representing the player state.
  */
 + (YTPlayerState)playerStateForString:(NSString *)stateString {
-    YTPlayerState state = kYTPlayerStateUnknown;
-    if ([stateString isEqualToString:kYTPlayerStateUnstartedCode]) {
-        state = kYTPlayerStateUnstarted;
-    } else if ([stateString isEqualToString:kYTPlayerStateEndedCode]) {
-        state = kYTPlayerStateEnded;
-    } else if ([stateString isEqualToString:kYTPlayerStatePlayingCode]) {
-        state = kYTPlayerStatePlaying;
-    } else if ([stateString isEqualToString:kYTPlayerStatePausedCode]) {
-        state = kYTPlayerStatePaused;
-    } else if ([stateString isEqualToString:kYTPlayerStateBufferingCode]) {
-        state = kYTPlayerStateBuffering;
-    } else if ([stateString isEqualToString:kYTPlayerStateCuedCode]) {
-        state = kYTPlayerStateQueued;
-    }
-    return state;
+  YTPlayerState state = kYTPlayerStateUnknown;
+  if ([stateString isEqualToString:kYTPlayerStateUnstartedCode]) {
+    state = kYTPlayerStateUnstarted;
+  } else if ([stateString isEqualToString:kYTPlayerStateEndedCode]) {
+    state = kYTPlayerStateEnded;
+  } else if ([stateString isEqualToString:kYTPlayerStatePlayingCode]) {
+    state = kYTPlayerStatePlaying;
+  } else if ([stateString isEqualToString:kYTPlayerStatePausedCode]) {
+    state = kYTPlayerStatePaused;
+  } else if ([stateString isEqualToString:kYTPlayerStateBufferingCode]) {
+    state = kYTPlayerStateBuffering;
+  } else if ([stateString isEqualToString:kYTPlayerStateCuedCode]) {
+    state = kYTPlayerStateQueued;
+  }
+  return state;
 }
 
 /**
@@ -491,22 +481,22 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
  * @return A string value to be used in the JavaScript bridge.
  */
 + (NSString *)stringForPlayerState:(YTPlayerState)state {
-    switch (state) {
-        case kYTPlayerStateUnstarted:
-            return kYTPlayerStateUnstartedCode;
-        case kYTPlayerStateEnded:
-            return kYTPlayerStateEndedCode;
-        case kYTPlayerStatePlaying:
-            return kYTPlayerStatePlayingCode;
-        case kYTPlayerStatePaused:
-            return kYTPlayerStatePausedCode;
-        case kYTPlayerStateBuffering:
-            return kYTPlayerStateBufferingCode;
-        case kYTPlayerStateQueued:
-            return kYTPlayerStateCuedCode;
-        default:
-            return kYTPlayerStateUnknownCode;
-    }
+  switch (state) {
+    case kYTPlayerStateUnstarted:
+      return kYTPlayerStateUnstartedCode;
+    case kYTPlayerStateEnded:
+      return kYTPlayerStateEndedCode;
+    case kYTPlayerStatePlaying:
+      return kYTPlayerStatePlayingCode;
+    case kYTPlayerStatePaused:
+      return kYTPlayerStatePausedCode;
+    case kYTPlayerStateBuffering:
+      return kYTPlayerStateBufferingCode;
+    case kYTPlayerStateQueued:
+      return kYTPlayerStateCuedCode;
+    default:
+      return kYTPlayerStateUnknownCode;
+  }
 }
 
 #pragma mark - Private methods
@@ -520,85 +510,85 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
  * @param url A URL of the format http://ytplayer/action.
  */
 - (void)notifyDelegateOfYouTubeCallbackUrl: (NSURL *) url {
-    NSString *action = url.host;
-    
-    // We know the query can only be of the format http://ytplayer?data=SOMEVALUE,
-    // so we parse out the value.
-    NSString *query = url.query;
-    NSString *data;
-    if (query) {
-        data = [query componentsSeparatedByString:@"="][1];
+  NSString *action = url.host;
+
+  // We know the query can only be of the format http://ytplayer?data=SOMEVALUE,
+  // so we parse out the value.
+  NSString *query = url.query;
+  NSString *data;
+  if (query) {
+    data = [query componentsSeparatedByString:@"="][1];
+  }
+
+  if ([action isEqual:kYTPlayerCallbackOnReady]) {
+    if ([self.delegate respondsToSelector:@selector(playerViewDidBecomeReady:)]) {
+      [self.delegate playerViewDidBecomeReady:self];
     }
-    
-    if ([action isEqual:kYTPlayerCallbackOnReady]) {
-        if ([self.delegate respondsToSelector:@selector(playerViewDidBecomeReady:)]) {
-            [self.delegate playerViewDidBecomeReady:self];
-        }
-    } else if ([action isEqual:kYTPlayerCallbackOnStateChange]) {
-        if ([self.delegate respondsToSelector:@selector(playerView:didChangeToState:)]) {
-            YTPlayerState state = kYTPlayerStateUnknown;
-            
-            if ([data isEqual:kYTPlayerStateEndedCode]) {
-                state = kYTPlayerStateEnded;
-            } else if ([data isEqual:kYTPlayerStatePlayingCode]) {
-                state = kYTPlayerStatePlaying;
-            } else if ([data isEqual:kYTPlayerStatePausedCode]) {
-                state = kYTPlayerStatePaused;
-            } else if ([data isEqual:kYTPlayerStateBufferingCode]) {
-                state = kYTPlayerStateBuffering;
-            } else if ([data isEqual:kYTPlayerStateCuedCode]) {
-                state = kYTPlayerStateQueued;
-            } else if ([data isEqual:kYTPlayerStateUnstartedCode]) {
-                state = kYTPlayerStateUnstarted;
-            }
-            
-            [self.delegate playerView:self didChangeToState:state];
-        }
-    } else if ([action isEqual:kYTPlayerCallbackOnPlaybackQualityChange]) {
-        if ([self.delegate respondsToSelector:@selector(playerView:didChangeToQuality:)]) {
-            YTPlaybackQuality quality = [YTPlayerView playbackQualityForString:data];
-            [self.delegate playerView:self didChangeToQuality:quality];
-        }
-    } else if ([action isEqual:kYTPlayerCallbackOnError]) {
-        if ([self.delegate respondsToSelector:@selector(playerView:receivedError:)]) {
-            YTPlayerError error = kYTPlayerErrorUnknown;
-            
-            if ([data isEqual:kYTPlayerErrorInvalidParamErrorCode]) {
-                error = kYTPlayerErrorInvalidParam;
-            } else if ([data isEqual:kYTPlayerErrorHTML5ErrorCode]) {
-                error = kYTPlayerErrorHTML5Error;
-            } else if ([data isEqual:kYTPlayerErrorNotEmbeddableErrorCode]) {
-                error = kYTPlayerErrorNotEmbeddable;
-            } else if ([data isEqual:kYTPlayerErrorVideoNotFoundErrorCode] ||
-                       [data isEqual:kYTPlayerErrorCannotFindVideoErrorCode]) {
-                error = kYTPlayerErrorVideoNotFound;
-            }
-            
-            [self.delegate playerView:self receivedError:error];
-        }
+  } else if ([action isEqual:kYTPlayerCallbackOnStateChange]) {
+    if ([self.delegate respondsToSelector:@selector(playerView:didChangeToState:)]) {
+      YTPlayerState state = kYTPlayerStateUnknown;
+
+      if ([data isEqual:kYTPlayerStateEndedCode]) {
+        state = kYTPlayerStateEnded;
+      } else if ([data isEqual:kYTPlayerStatePlayingCode]) {
+        state = kYTPlayerStatePlaying;
+      } else if ([data isEqual:kYTPlayerStatePausedCode]) {
+        state = kYTPlayerStatePaused;
+      } else if ([data isEqual:kYTPlayerStateBufferingCode]) {
+        state = kYTPlayerStateBuffering;
+      } else if ([data isEqual:kYTPlayerStateCuedCode]) {
+        state = kYTPlayerStateQueued;
+      } else if ([data isEqual:kYTPlayerStateUnstartedCode]) {
+        state = kYTPlayerStateUnstarted;
+      }
+
+      [self.delegate playerView:self didChangeToState:state];
     }
+  } else if ([action isEqual:kYTPlayerCallbackOnPlaybackQualityChange]) {
+    if ([self.delegate respondsToSelector:@selector(playerView:didChangeToQuality:)]) {
+      YTPlaybackQuality quality = [YTPlayerView playbackQualityForString:data];
+      [self.delegate playerView:self didChangeToQuality:quality];
+    }
+  } else if ([action isEqual:kYTPlayerCallbackOnError]) {
+    if ([self.delegate respondsToSelector:@selector(playerView:receivedError:)]) {
+      YTPlayerError error = kYTPlayerErrorUnknown;
+
+      if ([data isEqual:kYTPlayerErrorInvalidParamErrorCode]) {
+        error = kYTPlayerErrorInvalidParam;
+      } else if ([data isEqual:kYTPlayerErrorHTML5ErrorCode]) {
+        error = kYTPlayerErrorHTML5Error;
+      } else if ([data isEqual:kYTPlayerErrorNotEmbeddableErrorCode]) {
+        error = kYTPlayerErrorNotEmbeddable;
+      } else if ([data isEqual:kYTPlayerErrorVideoNotFoundErrorCode] ||
+          [data isEqual:kYTPlayerErrorCannotFindVideoErrorCode]) {
+        error = kYTPlayerErrorVideoNotFound;
+      }
+
+      [self.delegate playerView:self receivedError:error];
+    }
+  }
 }
 
 - (BOOL)handleHttpNavigationToUrl:(NSURL *) url {
-    // Usually this means the user has clicked on the YouTube logo or an error message in the
-    // player. Most URLs should open in the browser. The only http(s) URL that should open in this
-    // UIWebView is the URL for the embed, which is of the format:
-    //     http(s)://www.youtube.com/embed/[VIDEO ID]?[PARAMETERS]
-    NSError *error = NULL;
-    NSRegularExpression *regex =
-    [NSRegularExpression regularExpressionWithPattern:kYTPlayerEmbedUrlRegexPattern
-                                              options:NSRegularExpressionCaseInsensitive
-                                                error:&error];
-    NSTextCheckingResult *match =
-    [regex firstMatchInString:url.absoluteString
-                      options:0
-                        range:NSMakeRange(0, [url.absoluteString length])];
-    if (match) {
-        return YES;
-    } else {
-        [[UIApplication sharedApplication] openURL:url];
-        return NO;
-    }
+  // Usually this means the user has clicked on the YouTube logo or an error message in the
+  // player. Most URLs should open in the browser. The only http(s) URL that should open in this
+  // UIWebView is the URL for the embed, which is of the format:
+  //     http(s)://www.youtube.com/embed/[VIDEO ID]?[PARAMETERS]
+  NSError *error = NULL;
+  NSRegularExpression *regex =
+      [NSRegularExpression regularExpressionWithPattern:kYTPlayerEmbedUrlRegexPattern
+                                                options:NSRegularExpressionCaseInsensitive
+                                                  error:&error];
+  NSTextCheckingResult *match =
+      [regex firstMatchInString:url.absoluteString
+                        options:0
+                          range:NSMakeRange(0, [url.absoluteString length])];
+  if (match) {
+    return YES;
+  } else {
+    [[UIApplication sharedApplication] openURL:url];
+    return NO;
+  }
 }
 
 
@@ -611,73 +601,61 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
  * @return YES if successful, NO if not.
  */
 - (BOOL)loadWithPlayerParams:(NSDictionary *)additionalPlayerParams {
-    NSDictionary *playerCallbacks = @{
-                                      @"onReady" : @"onReady",
-                                      @"onStateChange" : @"onStateChange",
-                                      @"onPlaybackQualityChange" : @"onPlaybackQualityChange",
-                                      @"onError" : @"onPlayerError"
-                                      };
-    
-    //100% makes the player fit its bounds without losing its aspect. Video never loses aspect though.
-    //By setting the height to the view limits the player will the view completely.
-    NSString *heightString;
-    NSString *widthString;
-    if (self.shouldFillBounds) {
-        heightString = [NSString stringWithFormat:@"%.0f", self.bounds.size.height];
-        widthString = [NSString stringWithFormat:@"%.0f", self.bounds.size.width];
-    }
-    else {
-        heightString = widthString = @"100%";
-    }
-    NSMutableDictionary *playerParams = [[NSMutableDictionary alloc] init];
-    [playerParams addEntriesFromDictionary:additionalPlayerParams];
-    [playerParams setValue:heightString forKey:@"height"];
-    [playerParams setValue:widthString forKey:@"width"];
-    [playerParams setValue:playerCallbacks forKey:@"events"];
-    
-    // This must not be empty so we can render a '{}' in the output JSON
-    if (![playerParams objectForKey:@"playerVars"]) {
-        [playerParams setValue:[[NSDictionary alloc] init] forKey:@"playerVars"];
-    }
-    
-    // Remove the existing webView to reset any state
-    [self.webView removeFromSuperview];
-    _webView = [self createNewWebView];
-    [self addSubview:self.webView];
-    
-    NSError *error = nil;
-    NSString *path = [[NSBundle mainBundle] pathForResource:@"YTPlayerView-iframe-player"
-                                                     ofType:@"html"
-                                                inDirectory:@"Assets"];
-    NSString *embedHTMLTemplate =
-    [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:&error];
-    
-    if (error) {
-        NSLog(@"Received error rendering template: %@", error);
-        return NO;
-    }
-    
-    // Render the playerVars as a JSON dictionary.
-    NSError *jsonRenderingError = nil;
-    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:playerParams
-                                                       options:NSJSONWritingPrettyPrinted
-                                                         error:&jsonRenderingError];
-    if (jsonRenderingError) {
-        NSLog(@"Attempted configuration of player with invalid playerVars: %@ \tError: %@",
-              playerParams,
-              jsonRenderingError);
-        return NO;
-    }
-    
-    NSString *playerVarsJsonString =
-    [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-    
-    NSString *embedHTML = [NSString stringWithFormat:embedHTMLTemplate, playerVarsJsonString];
-    [self.webView loadHTMLString:embedHTML baseURL:[NSURL URLWithString:@"about:blank"]];
-    [self.webView setDelegate:self];
-    self.webView.allowsInlineMediaPlayback = YES;
-    self.webView.mediaPlaybackRequiresUserAction = NO;
-    return YES;
+  NSDictionary *playerCallbacks = @{
+        @"onReady" : @"onReady",
+        @"onStateChange" : @"onStateChange",
+        @"onPlaybackQualityChange" : @"onPlaybackQualityChange",
+        @"onError" : @"onPlayerError"
+  };
+  NSMutableDictionary *playerParams = [[NSMutableDictionary alloc] init];
+  [playerParams addEntriesFromDictionary:additionalPlayerParams];
+  [playerParams setValue:@"100%" forKey:@"height"];
+  [playerParams setValue:@"100%" forKey:@"width"];
+  [playerParams setValue:playerCallbacks forKey:@"events"];
+
+  // This must not be empty so we can render a '{}' in the output JSON
+  if (![playerParams objectForKey:@"playerVars"]) {
+    [playerParams setValue:[[NSDictionary alloc] init] forKey:@"playerVars"];
+  }
+
+  // Remove the existing webView to reset any state
+  [self.webView removeFromSuperview];
+  _webView = [self createNewWebView];
+  [self addSubview:self.webView];
+
+  NSError *error = nil;
+  NSString *path = [[NSBundle mainBundle] pathForResource:@"YTPlayerView-iframe-player"
+                                                   ofType:@"html"
+                                              inDirectory:@"Assets"];
+  NSString *embedHTMLTemplate =
+      [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:&error];
+
+  if (error) {
+    NSLog(@"Received error rendering template: %@", error);
+    return NO;
+  }
+
+  // Render the playerVars as a JSON dictionary.
+  NSError *jsonRenderingError = nil;
+  NSData *jsonData = [NSJSONSerialization dataWithJSONObject:playerParams
+                                                     options:NSJSONWritingPrettyPrinted
+                                                       error:&jsonRenderingError];
+  if (jsonRenderingError) {
+    NSLog(@"Attempted configuration of player with invalid playerVars: %@ \tError: %@",
+          playerParams,
+          jsonRenderingError);
+    return NO;
+  }
+
+  NSString *playerVarsJsonString =
+      [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+
+  NSString *embedHTML = [NSString stringWithFormat:embedHTMLTemplate, playerVarsJsonString];
+  [self.webView loadHTMLString:embedHTML baseURL:[NSURL URLWithString:@"about:blank"]];
+  [self.webView setDelegate:self];
+  self.webView.allowsInlineMediaPlayback = YES;
+  self.webView.mediaPlaybackRequiresUserAction = NO;
+  return YES;
 }
 
 /**
@@ -692,15 +670,15 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
  * @return The result of cueing the playlist.
  */
 - (void)cuePlaylist:(NSString *)cueingString
-              index:(int)index
-       startSeconds:(float)startSeconds
-   suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-    NSNumber *indexValue = [NSNumber numberWithInt:index];
-    NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
-    NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
-    NSString *command = [NSString stringWithFormat:@"player.cuePlaylist(%@, %@, %@, '%@');",
-                         cueingString, indexValue, startSecondsValue, qualityValue];
-    [self stringFromEvaluatingJavaScript:command];
+               index:(int)index
+        startSeconds:(float)startSeconds
+    suggestedQuality:(YTPlaybackQuality)suggestedQuality {
+  NSNumber *indexValue = [NSNumber numberWithInt:index];
+  NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
+  NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
+  NSString *command = [NSString stringWithFormat:@"player.cuePlaylist(%@, %@, %@, '%@');",
+      cueingString, indexValue, startSecondsValue, qualityValue];
+  [self stringFromEvaluatingJavaScript:command];
 }
 
 /**
@@ -718,12 +696,12 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
                index:(int)index
         startSeconds:(float)startSeconds
     suggestedQuality:(YTPlaybackQuality)suggestedQuality {
-    NSNumber *indexValue = [NSNumber numberWithInt:index];
-    NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
-    NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
-    NSString *command = [NSString stringWithFormat:@"player.loadPlaylist(%@, %@, %@, '%@');",
-                         cueingString, indexValue, startSecondsValue, qualityValue];
-    [self stringFromEvaluatingJavaScript:command];
+  NSNumber *indexValue = [NSNumber numberWithInt:index];
+  NSNumber *startSecondsValue = [NSNumber numberWithFloat:startSeconds];
+  NSString *qualityValue = [YTPlayerView stringForPlaybackQuality:suggestedQuality];
+  NSString *command = [NSString stringWithFormat:@"player.loadPlaylist(%@, %@, %@, '%@');",
+      cueingString, indexValue, startSecondsValue, qualityValue];
+  [self stringFromEvaluatingJavaScript:command];
 }
 
 /**
@@ -733,13 +711,13 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
  * @return A JavaScript array in String format containing video IDs.
  */
 - (NSString *)stringFromVideoIdArray:(NSArray *)videoIds {
-    NSMutableArray *formattedVideoIds = [[NSMutableArray alloc] init];
-    
-    for (id unformattedId in videoIds) {
-        [formattedVideoIds addObject:[NSString stringWithFormat:@"'%@'", unformattedId]];
-    }
-    
-    return [NSString stringWithFormat:@"[%@]", [formattedVideoIds componentsJoinedByString:@", "]];
+  NSMutableArray *formattedVideoIds = [[NSMutableArray alloc] init];
+
+  for (id unformattedId in videoIds) {
+    [formattedVideoIds addObject:[NSString stringWithFormat:@"'%@'", unformattedId]];
+  }
+
+  return [NSString stringWithFormat:@"[%@]", [formattedVideoIds componentsJoinedByString:@", "]];
 }
 
 /**
@@ -749,7 +727,7 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
  * @return JavaScript response from evaluating code.
  */
 - (NSString *)stringFromEvaluatingJavaScript:(NSString *)jsToExecute {
-    return [self.webView stringByEvaluatingJavaScriptFromString:jsToExecute];
+  return [self.webView stringByEvaluatingJavaScriptFromString:jsToExecute];
 }
 
 /**
@@ -759,20 +737,20 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
  * @return JavaScript Boolean value, i.e. "true" or "false".
  */
 - (NSString *)stringForJSBoolean:(BOOL)boolValue {
-    return boolValue ? @"true" : @"false";
+  return boolValue ? @"true" : @"false";
 }
 
 #pragma mark Exposed for Testing
 - (void)setWebView:(UIWebView *)webView {
-    _webView = webView;
+  _webView = webView;
 }
 
 - (UIWebView *)createNewWebView {
-    UIWebView *webView = [[UIWebView alloc] initWithFrame:self.bounds];
-    webView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
-    webView.scrollView.scrollEnabled = NO;
-    webView.scrollView.bounces = NO;
-    return webView;
+  UIWebView *webView = [[UIWebView alloc] initWithFrame:self.bounds];
+  webView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
+  webView.scrollView.scrollEnabled = NO;
+  webView.scrollView.bounces = NO;
+  return webView;
 }
 
 @end

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ it simply add the following line to your Podfile:
 
     pod "youtube-ios-player-helper", "~> 0.1.1"
 
+Or, for this fork:
+
+    pod 'youtube-ios-player-helper', :git => 'https://github.com/scondoo/youtube-ios-player-helper.git'
+
 After installing in your project and opening the workspace, to use the library:
 
   1. Drag a UIView the desired size of your player onto your Storyboard.

--- a/youtube-ios-player-helper.podspec
+++ b/youtube-ios-player-helper.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
   s.author             = { "Ikai Lan" => "ikai@google.com",
                            "Yoshifumi Yamaguchi" => "yoshifumi@google.com" }
   s.social_media_url   = "https://twitter.com/YouTubeDev"
-  s.source             = { :git => "https://github.com/scondoo/youtube-ios-player-helper.git", :tag => “0.1.2” }
+  s.source             = { :git => "https://github.com/banaslee/youtube-ios-player-helper.git", :tag => "0.1.2" }
 
   s.platform     = :ios, '6.1'
   s.requires_arc = true

--- a/youtube-ios-player-helper.podspec
+++ b/youtube-ios-player-helper.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name              = "youtube-ios-player-helper"
-  s.version           = "0.1.1"
+  s.version           = “0.1.2”
   s.summary           = "Helper library for iOS developers that want to embed YouTube videos in
                          their iOS apps with the iframe player API."
 

--- a/youtube-ios-player-helper.podspec
+++ b/youtube-ios-player-helper.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
   s.author             = { "Ikai Lan" => "ikai@google.com",
                            "Yoshifumi Yamaguchi" => "yoshifumi@google.com" }
   s.social_media_url   = "https://twitter.com/YouTubeDev"
-  s.source             = { :git => "https://github.com/banaslee/youtube-ios-player-helper.git", :tag => "0.1.2" }
+  s.source             = { :git => "https://github.com/scondoo/youtube-ios-player-helper.git", :tag => "0.1.2" }
 
   s.platform     = :ios, '6.1'
   s.requires_arc = true

--- a/youtube-ios-player-helper.podspec
+++ b/youtube-ios-player-helper.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
   s.author             = { "Ikai Lan" => "ikai@google.com",
                            "Yoshifumi Yamaguchi" => "yoshifumi@google.com" }
   s.social_media_url   = "https://twitter.com/YouTubeDev"
-  s.source             = { :git => "https://github.com/youtube/youtube-ios-player-helper.git", :tag => "0.1.1" }
+  s.source             = { :git => "https://github.com/scondoo/youtube-ios-player-helper.git", :tag => “0.1.2” }
 
   s.platform     = :ios, '6.1'
   s.requires_arc = true

--- a/youtube-ios-player-helper.podspec
+++ b/youtube-ios-player-helper.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name              = "youtube-ios-player-helper"
-  s.version           = “0.1.2”
+  s.version           = "0.1.2"
   s.summary           = "Helper library for iOS developers that want to embed YouTube videos in
                          their iOS apps with the iframe player API."
 


### PR DESCRIPTION
Added ```fillBounds``` property to make the player fit the view's bounds instead of fitting the video;
Added a new callback ```- (void)playerStartedLoading:(YTPlayerView *)playerView``` for when the ```webview``` starts loading the player. This is useful to have more control over playback controls state.

Please ignore the changes done to the podspec file (noob mistake?).