### PR TITLE
Converted enums to NS_ENUM for Swift compatibility.

### DIFF
--- a/Classes/YTPlayerView.h
+++ b/Classes/YTPlayerView.h
@@ -17,7 +17,7 @@
 @class YTPlayerView;
 
 /** These enums represent the state of the current video in the player. */
-typedef enum {
+typedef NS_ENUM(NSInteger, YTPlayerState) {
     kYTPlayerStateUnstarted,
     kYTPlayerStateEnded,
     kYTPlayerStatePlaying,
@@ -25,10 +25,10 @@ typedef enum {
     kYTPlayerStateBuffering,
     kYTPlayerStateQueued,
     kYTPlayerStateUnknown
-} YTPlayerState;
+};
 
 /** These enums represent the resolution of the currently loaded video. */
-typedef enum {
+typedef NS_ENUM(NSInteger, YTPlaybackQuality) {
     kYTPlaybackQualitySmall,
     kYTPlaybackQualityMedium,
     kYTPlaybackQualityLarge,
@@ -36,17 +36,17 @@ typedef enum {
     kYTPlaybackQualityHD1080,
     kYTPlaybackQualityHighRes,
     kYTPlaybackQualityUnknown /** This should never be returned. It is here for future proofing. */
-} YTPlaybackQuality;
+};
 
 /** These enums represent error codes thrown by the player. */
-typedef enum {
+typedef NS_ENUM(NSInteger, YTPlayerError) {
     kYTPlayerErrorInvalidParam,
     kYTPlayerErrorHTML5Error,
     kYTPlayerErrorVideoNotFound, // Functionally equivalent error codes 100 and
     // 105 have been collapsed into |kYTPlayerErrorVideoNotFound|.
     kYTPlayerErrorNotEmbeddable,
     kYTPlayerErrorUnknown
-} YTPlayerError;
+};
 
 /**
  * A delegate for ViewControllers to respond to YouTube player events outside

--- a/Project/youtube-player-ios-example/youtube-player-ios-example/SingleVideoViewController.m
+++ b/Project/youtube-player-ios-example/youtube-player-ios-example/SingleVideoViewController.m
@@ -39,7 +39,7 @@
 }
 
 - (void)playerView:(YTPlayerView *)ytPlayerView changedStateTo:(YTPlayerState)state {
-  NSString *message = [NSString stringWithFormat:@"Player state changed: %u\n", state];
+  NSString *message = [NSString stringWithFormat:@"Player state changed: %ld\n", (long)state];
   [self appendStatusText:message];
 }
 


### PR DESCRIPTION

This should fix https://github.com/youtube/youtube-ios-player-helper/issues/21 - converted the current enums to NS_ENUM for Swift compatibility. I tested on hardware but didn't think new unit tests would be necessary.