### PR TITLE
Fixed cut-off bottom of 16:9 videos

### DIFF
--- a/Assets/YTPlayerView-iframe-player.html
+++ b/Assets/YTPlayerView-iframe-player.html
@@ -27,6 +27,7 @@
     var player;
     YT.ready(function() {
       player = new YT.Player('player', %@);
+      player.setSize(window.innerWidth, window.innerHeight);
       window.location.href = 'ytplayer://onYouTubeIframeAPIReady';
     });
     function onReady(event) {
@@ -41,6 +42,9 @@
     }
     function onPlayerError(event) {
         window.location.href = 'ytplayer://onError?data=' + event.data;
+    }
+    window.onresize = function() {
+        player.setSize(window.innerWidth, window.innerHeight);
     }
     </script>
 </body>

--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -609,8 +609,8 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
   };
   NSMutableDictionary *playerParams = [[NSMutableDictionary alloc] init];
   [playerParams addEntriesFromDictionary:additionalPlayerParams];
-  [playerParams setValue:[NSNumber numberWithFloat:CGRectGetHeight(self.bounds)] forKey:@"height"];
-  [playerParams setValue:[NSNumber numberWithFloat:CGRectGetWidth(self.bounds)] forKey:@"width"];
+  [playerParams setValue:@"100%" forKey:@"height"];
+  [playerParams setValue:@"100%" forKey:@"width"];
   [playerParams setValue:playerCallbacks forKey:@"events"];
 
   // This must not be empty so we can render a '{}' in the output JSON

--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -609,8 +609,8 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
   };
   NSMutableDictionary *playerParams = [[NSMutableDictionary alloc] init];
   [playerParams addEntriesFromDictionary:additionalPlayerParams];
-  [playerParams setValue:@"100%" forKey:@"height"];
-  [playerParams setValue:@"100%" forKey:@"width"];
+  [playerParams setValue:[NSNumber numberWithFloat:CGRectGetHeight(self.bounds)] forKey:@"height"];
+  [playerParams setValue:[NSNumber numberWithFloat:CGRectGetWidth(self.bounds)] forKey:@"width"];
   [playerParams setValue:playerCallbacks forKey:@"events"];
 
   // This must not be empty so we can render a '{}' in the output JSON


### PR DESCRIPTION
Not sure if this affects other video aspect ratios but it was the only way to keep the lib from cutting off the bottom in my app. Let me know if you think there's a better way to approach this issue.