### PR TITLE
fix the issue when UIWebView javascript returns array

### DIFF
--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -367,18 +367,10 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
 
 - (NSArray *)availableQualityLevels {
   NSString *returnValue =
-      [self stringFromEvaluatingJavaScript:@"player.getAvailableQualityLevels();"];
+      [self stringFromEvaluatingJavaScript:@"player.getAvailableQualityLevels().toString();"];
+  if(!returnValue) return nil;
 
-  NSData *availableQualityLevelsData = [returnValue dataUsingEncoding:NSUTF8StringEncoding];
-  NSError *jsonDeserializationError;
-
-  NSArray *rawQualityValues = [NSJSONSerialization JSONObjectWithData:availableQualityLevelsData
-                                                              options:kNilOptions
-                                                                error:&jsonDeserializationError];
-  if (jsonDeserializationError) {
-    return nil;
-  }
-
+  NSArray *rawQualityValues = [returnValue componentsSeparatedByString:@","];
   NSMutableArray *levels = [[NSMutableArray alloc] init];
   for (NSString *rawQualityValue in rawQualityValues) {
     YTPlaybackQuality quality = [YTPlayerView playbackQualityForString:rawQualityValue];


### PR DESCRIPTION
[UIWebview stringByEvaluatingJavaScriptFromString: ] only returns the correct data if the data is string
When executing player.getAvailablePlaybackRates(); it returns an array, so the quality array will never
be passed to the Objective C array.
fixed this issue by adding toString() on the javascript command, and parse the returned string int a NSArray
with [NSString componentsSeparatedByString:] 