### PR TITLE
Added 'Auto' Quality Constant

### DIFF
--- a/Classes/YTPlayerView.h
+++ b/Classes/YTPlayerView.h
@@ -35,6 +35,7 @@ typedef NS_ENUM(NSInteger, YTPlaybackQuality) {
     kYTPlaybackQualityHD720,
     kYTPlaybackQualityHD1080,
     kYTPlaybackQualityHighRes,
+    kYTPlaybackQualityAuto, /** Addition for YouTube Live Events. */
     kYTPlaybackQualityUnknown /** This should never be returned. It is here for future proofing. */
 };
 

--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -34,6 +34,7 @@ NSString static *const kYTPlaybackQualityLargeQuality = @"large";
 NSString static *const kYTPlaybackQualityHD720Quality = @"hd720";
 NSString static *const kYTPlaybackQualityHD1080Quality = @"hd1080";
 NSString static *const kYTPlaybackQualityHighResQuality = @"highres";
+NSString static *const kYTPlaybackQualityAutoQuality = @"auto";
 NSString static *const kYTPlaybackQualityUnknownQuality = @"unknown";
 
 // Constants representing YouTube player errors.
@@ -418,6 +419,8 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
     quality = kYTPlaybackQualityHD1080;
   } else if ([qualityString isEqualToString:kYTPlaybackQualityHighResQuality]) {
     quality = kYTPlaybackQualityHighRes;
+  } else if ([qualityString isEqualToString:kYTPlaybackQualityAutoQuality]) {
+    quality = kYTPlaybackQualityAuto;
   }
 
   return quality;
@@ -441,6 +444,8 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
       return kYTPlaybackQualityHD720Quality;
     case kYTPlaybackQualityHD1080:
       return kYTPlaybackQualityHD1080Quality;
+    case kYTPlaybackQualityHighRes:
+      return kYTPlaybackQualityHighResQuality;
     case kYTPlaybackQualityHighRes:
       return kYTPlaybackQualityHighResQuality;
     default:

--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -446,8 +446,8 @@ NSString static *const kYTPlayerEmbedUrlRegexPattern = @"^http(s)://(www.)youtub
       return kYTPlaybackQualityHD1080Quality;
     case kYTPlaybackQualityHighRes:
       return kYTPlaybackQualityHighResQuality;
-    case kYTPlaybackQualityHighRes:
-      return kYTPlaybackQualityHighResQuality;
+    case kYTPlaybackQualityAuto:
+      return kYTPlaybackQualityAutoQuality;
     default:
       return kYTPlaybackQualityUnknownQuality;
   }


### PR DESCRIPTION
This pull request adds a constant to account for cases when "Auto" quality is returned from YouTube. I've found this happens mostly when watching YouTube Live Events with the `YTPlayerView`.  I have modified this PR from #55 to adhere to more of the guidelines for contributing.

Tested on iPhones 4s through 6 Plus running iOS 8.1.x.  Please let me know if you need any more information.  I have signed the individual CLA.