### PR TITLE
Issue with origin not been part of playerVars

### DIFF
--- a/Assets/YTPlayerView-iframe-player.html
+++ b/Assets/YTPlayerView-iframe-player.html
@@ -54,97 +54,12 @@
     });
 
     function onReady(event) {
-        player.paused = false;
-        player.interrupted = false;
-
-        player.oldPlayVideo = player.playVideo;
-        player.playVideo = function() {
-           this.paused = false;
-           this.interrupted = false;
-
-           this.oldPlayVideo();
-        }
-        player.oldPauseVideo = player.pauseVideo;
-        player.pauseVideo = function() {
-           this.paused = true;
-           this.interrupted = false;
-
-           this.oldPauseVideo();
-        }
-        player.oldStopVideo = player.stopVideo;
-        player.stopVideo = function() {
-           // This has to be done on some other place, because if replay is on, it won't work
-           this.paused = false;
-           this.interrupted = false;
-
-           this.oldStopVideo();
-        }
-
-        player.oldClearVideo = player.clearVideo;
-        player.clearVideo = function() {
-           this.paused = false;
-           this.interrupted = false;
-
-           this.oldClearVideo();
-        }
-
-        function forcePlay() {
-           if (player.interrupted) {
-               player.oldPlayVideo();
-               window.location.href = 'ytplayer://onStateChange?data=' + YT.PlayerState.PLAYING;
-           }
-        }
-
-        window.setInterval(forcePlay, 5000);
         window.location.href = 'ytplayer://onReady?data=' + event.data;
-
     }
+
     function onStateChange(event) {
-        if (!error) {
-            
-            /**
-             * This code here is temporary and is in place to handle pause initiated by the api player.
-             * if user is has low connectivity a force play will not happen.
-             */
-            player.interrupted = false;
-
-             switch(event.data) {
-                case YT.PlayerState.PAUSED :
-                    player.paused = true;
-                    break;
-
-                case YT.PlayerState.sPLAYING:
-                    player.paused = false;
-
-                default:
-                    break;
-             }
-            
+        if (!error) {            
             window.location.href = 'ytplayer://onStateChange?data=' + event.data;
-
-            /* * 
-             * @samiq: Commenting this part of the code until a better solution comes out to handle
-             * unrequested pause of video.
-             *
-            // Send notification for all states but Paused and for Paused if the user did pause.
-            if (event.data != YT.PlayerState.PAUSED) {
-                // The player state has changed and obviously it is not interrupted.
-                // Notify the delegate that the state changed.
-                player.interrupted = false;
-
-                window.location.href = 'ytplayer://onStateChange?data=' + event.data;
-
-            } else {
-                if (player.paused == true){
-                    // User has paused. Notify the delegate that the state changed.
-                    window.location.href = 'ytplayer://onStateChange?data=' + event.data;
-                }
-                else {
-                    // Youtube player API tried to pause internaly, do not pause.
-                    player.interrupted = true;
-                }
-            }
-            */
         }
         else {
             error = false;
@@ -154,12 +69,14 @@
     function onPlaybackQualityChange(event) {
         window.location.href = 'ytplayer://onPlaybackQualityChange?data=' + event.data;
     }
+
     function onPlayerError(event) {
         if (event.data == 100) {
             error = true;
         }
         window.location.href = 'ytplayer://onError?data=' + event.data;
     }
+    
     window.onresize = function() {
         player.setSize(window.innerWidth, window.innerHeight);
     }

--- a/Assets/YTPlayerView-iframe-player.html
+++ b/Assets/YTPlayerView-iframe-player.html
@@ -101,6 +101,31 @@
     }
     function onStateChange(event) {
         if (!error) {
+            
+            /**
+             * This code here is temporary and is in place to handle pause initiated by the api player.
+             * if user is has low connectivity a force play will not happen.
+             */
+            player.interrupted = false;
+
+             switch(event.data) {
+                case YT.PlayerState.PAUSED :
+                    player.paused = true;
+                    break;
+
+                case YT.PlayerState.sPLAYING:
+                    player.paused = false;
+
+                default:
+                    break;
+             }
+            
+            window.location.href = 'ytplayer://onStateChange?data=' + event.data;
+
+            /* * 
+             * @samiq: Commenting this part of the code until a better solution comes out to handle
+             * unrequested pause of video.
+             *
             // Send notification for all states but Paused and for Paused if the user did pause.
             if (event.data != YT.PlayerState.PAUSED) {
                 // The player state has changed and obviously it is not interrupted.
@@ -119,6 +144,7 @@
                     player.interrupted = true;
                 }
             }
+            */
         }
         else {
             error = false;

--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -629,16 +629,20 @@ NSString static *const kYTPlayerAdUrlRegexPattern = @"^http(s)://pubads.g.double
   if (![playerParams objectForKey:@"width"]) {
     [playerParams setValue:@"100%" forKey:@"width"];
   }
-  if (![playerParams objectForKey:@"origin"]) {
-    self.originURL = [NSURL URLWithString:@"about:blank"];
-  } else {
-    self.originURL = [NSURL URLWithString: [playerParams objectForKey:@"origin"]];
-  }
 
   [playerParams setValue:playerCallbacks forKey:@"events"];
 
-  // This must not be empty so we can render a '{}' in the output JSON
-  if (![playerParams objectForKey:@"playerVars"]) {
+  if ([playerParams objectForKey:@"playerVars"]) {
+    NSMutableDictionary *playerVars = [[NSMutableDictionary alloc] init];
+    [playerVars addEntriesFromDictionary:[playerParams objectForKey:@"playerVars"]];
+      
+    if (![playerVars objectForKey:@"origin"]) {
+        self.originURL = [NSURL URLWithString:@"about:blank"];
+    } else {
+        self.originURL = [NSURL URLWithString: [playerVars objectForKey:@"origin"]];
+    }
+  } else {
+    // This must not be empty so we can render a '{}' in the output JSON
     [playerParams setValue:[[NSDictionary alloc] init] forKey:@"playerVars"];
   }
 


### PR DESCRIPTION
“origin” property should be part of playerVars and should be set / get from there, in the current implementation “origin” cannot be passed to the loading process from the host class nor is been set correctly to the playerVars json object been passed to the page.