### PR TITLE
Added handling for error 150, according to the documentation for v3 API

### DIFF
--- a/Classes/YTPlayerView.h
+++ b/Classes/YTPlayerView.h
@@ -46,7 +46,8 @@ typedef NS_ENUM(NSInteger, YTPlayerError) {
     kYTPlayerErrorHTML5Error,
     kYTPlayerErrorVideoNotFound, // Functionally equivalent error codes 100 and
     // 105 have been collapsed into |kYTPlayerErrorVideoNotFound|.
-    kYTPlayerErrorNotEmbeddable,
+    kYTPlayerErrorNotEmbeddable, // Functionally equivalent error codes 101 and
+    // 150 have been collapsed into |kYTPlayerErrorNotEmbeddable|.
     kYTPlayerErrorUnknown
 };
 

--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -44,6 +44,7 @@ NSString static *const kYTPlayerErrorHTML5ErrorCode = @"5";
 NSString static *const kYTPlayerErrorVideoNotFoundErrorCode = @"100";
 NSString static *const kYTPlayerErrorNotEmbeddableErrorCode = @"101";
 NSString static *const kYTPlayerErrorCannotFindVideoErrorCode = @"105";
+NSString static *const kYTPlayerErrorSameAsNotEmbeddableErrorCode = @"150";
 
 // Constants representing player callbacks.
 NSString static *const kYTPlayerCallbackOnReady = @"onReady";
@@ -562,10 +563,11 @@ NSString static *const kYTPlayerAdUrlRegexPattern = @"^http(s)://pubads.g.double
         error = kYTPlayerErrorInvalidParam;
       } else if ([data isEqual:kYTPlayerErrorHTML5ErrorCode]) {
         error = kYTPlayerErrorHTML5Error;
-      } else if ([data isEqual:kYTPlayerErrorNotEmbeddableErrorCode]) {
+      } else if ([data isEqual:kYTPlayerErrorNotEmbeddableErrorCode] ||
+                 [data isEqual:kYTPlayerErrorSameAsNotEmbeddableErrorCode]) {
         error = kYTPlayerErrorNotEmbeddable;
       } else if ([data isEqual:kYTPlayerErrorVideoNotFoundErrorCode] ||
-          [data isEqual:kYTPlayerErrorCannotFindVideoErrorCode]) {
+                 [data isEqual:kYTPlayerErrorCannotFindVideoErrorCode]) {
         error = kYTPlayerErrorVideoNotFound;
       }
 


### PR DESCRIPTION
Ragarding the documentation for API V3 youtube also sends error code 150 for not embeddeable videos - https://developers.google.com/youtube/iframe_api_reference#onError

Cheers
Max
