### PR TITLE
Allowing custom styling of the webview background

### DIFF
--- a/Classes/YTPlayerView.h
+++ b/Classes/YTPlayerView.h
@@ -92,7 +92,6 @@ typedef NS_ENUM(NSInteger, YTPlayerError) {
  */
 - (void)playerView:(YTPlayerView *)playerView receivedError:(YTPlayerError)error;
 
-
 /**
  * Callback invoked frequently when playBack is plaing.
  *
@@ -100,6 +99,13 @@ typedef NS_ENUM(NSInteger, YTPlayerError) {
  * @param playTime float containing curretn playback time.
  */
 - (void)playerView:(YTPlayerView *)playerView didPlayTime:(float)playTime;
+
+/**
+ * Callback invoked when setting up the webview to allow custom colours so it fits in
+ * with app color schemes. If a transparent view is required specify clearColor and
+ * the code will handle the opacity etc.
+ */
+- (UIColor *)playerViewPreferredWebViewBackgroundColor:(YTPlayerView *)playerView;
 
 @end
 

--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -814,11 +814,19 @@ NSString static *const kYTPlayerStaticProxyRegexPattern = @"^https://content.goo
 }
 
 - (UIWebView *)createNewWebView {
-  UIWebView *webView = [[UIWebView alloc] initWithFrame:self.bounds];
-  webView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
-  webView.scrollView.scrollEnabled = NO;
-  webView.scrollView.bounces = NO;
-  return webView;
+    UIWebView *webView = [[UIWebView alloc] initWithFrame:self.bounds];
+    webView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
+    webView.scrollView.scrollEnabled = NO;
+    webView.scrollView.bounces = NO;
+    
+    if ([self.delegate respondsToSelector:@selector(playerViewPreferredWebViewBackgroundColor:)]) {
+        webView.backgroundColor = [self.delegate playerViewPreferredWebViewBackgroundColor];
+        if (webView.backgroundColor == [UIColor clearColor]) {
+            webView.opaque = NO
+        }
+    }
+    
+    return webView;
 }
 
 - (void)removeWebView {

--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -820,9 +820,9 @@ NSString static *const kYTPlayerStaticProxyRegexPattern = @"^https://content.goo
     webView.scrollView.bounces = NO;
     
     if ([self.delegate respondsToSelector:@selector(playerViewPreferredWebViewBackgroundColor:)]) {
-        webView.backgroundColor = [self.delegate playerViewPreferredWebViewBackgroundColor];
+        webView.backgroundColor = [self.delegate playerViewPreferredWebViewBackgroundColor:self];
         if (webView.backgroundColor == [UIColor clearColor]) {
-            webView.opaque = NO
+            webView.opaque = NO;
         }
     }
     


### PR DESCRIPTION
I wanted to be able to ensure the background matched in my app. Or more to the point, it inherited what was beneath it.

I've implemented an optional delegate callback allowing it to be specified if required. Tested and working using a pod reference to my repo (sadly in a private project).