### PR TITLE
Remove deprecated method: clearVideo

### DIFF
--- a/Classes/YTPlayerView.h
+++ b/Classes/YTPlayerView.h
@@ -238,13 +238,6 @@ typedef NS_ENUM(NSInteger, YTPlayerError) {
  */
 - (void)seekToSeconds:(float)seekToSeconds allowSeekAhead:(BOOL)allowSeekAhead;
 
-/**
- * Clears the loaded video from the player. Corresponds to this method from
- * the JavaScript API:
- *   https://developers.google.com/youtube/iframe_api_reference#clearVideo
- */
-- (void)clearVideo;
-
 #pragma mark - Queuing videos
 
 // Queueing functions for videos. These methods correspond to their JavaScript

--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -118,10 +118,6 @@ NSString static *const kYTPlayerStaticProxyRegexPattern = @"^https://content.goo
   [self stringFromEvaluatingJavaScript:command];
 }
 
-- (void)clearVideo {
-  [self stringFromEvaluatingJavaScript:@"player.clearVideo();"];
-}
-
 #pragma mark - Cueing methods
 
 - (void)cueVideoById:(NSString *)videoId

--- a/Project/youtube-player-ios-example/youtube-player-ios-exampleTests/youtube_player_ios_exampleTests.m
+++ b/Project/youtube-player-ios-example/youtube-player-ios-exampleTests/youtube_player_ios_exampleTests.m
@@ -149,12 +149,6 @@
   [mockWebView verify];
 }
 
-- (void)testClearVideo {
-  [[mockWebView expect] stringByEvaluatingJavaScriptFromString:@"player.clearVideo();"];
-  [playerView clearVideo];
-  [mockWebView verify];
-}
-
 - (void)testSeekTo {
   [[mockWebView expect] stringByEvaluatingJavaScriptFromString:@"player.seekTo(5.5, false);"];
   [playerView seekToSeconds:5.5 allowSeekAhead:NO];


### PR DESCRIPTION
"January 6, 2016 - The clearVideo function has been deprecated and removed from the documentation. The function no longer has any effect in the YouTube player."
Source: https://developers.google.com/youtube/iframe_api_reference#clearVideo