### PR TITLE
Handle x-apple-content-filter://blocked-page

### DIFF
--- a/Classes/YTPlayerView.h
+++ b/Classes/YTPlayerView.h
@@ -93,6 +93,14 @@ typedef NS_ENUM(NSInteger, YTPlayerError) {
 - (void)playerView:(nonnull YTPlayerView *)playerView receivedError:(YTPlayerError)error;
 
 /**
+ * Invoked when web access restrictions are enabled for the current device, and youtube.com is blocked.
+ * Check: Settings > General > Restrictions > Websites > Allowed Websites.
+ *
+ * @param error NSError containing the error state.
+ */
+- (void)playerViewAppleContentFilterBlockedPage:(NSError *)error;
+
+/**
  * Callback invoked frequently when playBack is plaing.
  *
  * @param playerView The YTPlayerView instance where the error has occurred.


### PR DESCRIPTION
Handle the case when youtube.com is blocked on device's Restrictions settings.