### PR TITLE
Support delegate callback when video is attempted to be played offline

### DIFF
--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -596,6 +596,11 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
     if (self.initialLoadingView) {
       [self.initialLoadingView removeFromSuperview];
     }
+    
+    if ([self.delegate respondsToSelector:@selector(playerView:receivedError:)]) {
+      YTPlayerError error = kYTPlayerErrorUnknown;
+      [self.delegate playerView:self receivedError:error];
+    }
   }
 }
 


### PR DESCRIPTION
If the iframe fails to load, perhaps because the user is offline, then call the delegate method to notify the client application (if implemented). This allows the client application to respond to this error rather than silently failing. 

This would address issue #182
