### PR TITLE
Disable picture in picture functionality 

### DIFF
--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -748,6 +748,7 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
   [self.webView setDelegate:self];
   self.webView.allowsInlineMediaPlayback = YES;
   self.webView.mediaPlaybackRequiresUserAction = NO;
+  self.webView.allowsPictureInPictureMediaPlayback = NO;
   
   if ([self.delegate respondsToSelector:@selector(playerViewPreferredInitialLoadingView:)]) {
     UIView *initialLoadingView = [self.delegate playerViewPreferredInitialLoadingView:self];


### PR DESCRIPTION
Disabling the picture in picture functionality for iPad users running iOS 9.0+.
The reported [issue](https://github.com/youtube/youtube-ios-player-helper/issues/211).

Basically, UIWebViews don't provide any callback functionality from the Picture in Picture view that is available to iPad users running iOS 9.0+, so I'm hoping to disable it entirely to prevent poor experiences watching videos using this library in picture in picture.