### PR TITLE
Look for YTPlayerView-iframe-player.html in main directory as well

### DIFF
--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -719,6 +719,13 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
                                                      ofType:@"html"
                                                 inDirectory:@"Assets"];
   }
+
+  // React-Native's bundler can only put resources files in the main bundle directory
+  if (!path) {
+      path = [[NSBundle bundleForClass:[YTPlayerView class]] pathForResource:@"YTPlayerView-iframe-player"
+                                                                      ofType:@"html"
+                                                                 inDirectory:nil];
+  }
     
   NSString *embedHTMLTemplate =
       [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:&error];


### PR DESCRIPTION
React-Native bundler for iOS can put resource files only in the bundle's main directory.
If the file wasn't found in Assets or in a Swift framework bundle, we should search for it there