### PR TITLE
Fixes full screen playback on iOS 10

### DIFF
--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -746,7 +746,10 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
   NSString *embedHTML = [NSString stringWithFormat:embedHTMLTemplate, playerVarsJsonString];
   [self.webView loadHTMLString:embedHTML baseURL: self.originURL];
   [self.webView setDelegate:self];
-  self.webView.allowsInlineMediaPlayback = YES;
+  
+  BOOL shouldPlayInline = [[playerParams objectForKey: @"playerVars"] objectForKey:@"playsinline"];
+  self.webView.allowsInlineMediaPlayback = shouldPlayInline;
+
   self.webView.mediaPlaybackRequiresUserAction = NO;
   
   if ([self.delegate respondsToSelector:@selector(playerViewPreferredInitialLoadingView:)]) {


### PR DESCRIPTION
Setting allowsInlineMediaPlayback to a check if playsInline params is set to true or false. 
Fixes #260 