### PR TITLE
Fixed some documentation issues (for avoiding Xcode warnings).

### DIFF
--- a/Classes/YTPlayerView.h
+++ b/Classes/YTPlayerView.h
@@ -611,7 +611,7 @@ typedef NS_ENUM(NSInteger, YTPlayerError) {
  * |default|. This method corresponds to the JavaScript API defined here:
  *   https://developers.google.com/youtube/iframe_api_reference#setPlaybackQuality
  *
- * @param quality YTPlaybackQuality value to suggest for the player.
+ * @param suggestedQuality YTPlaybackQuality value to suggest for the player.
  */
 - (void)setPlaybackQuality:(YTPlaybackQuality)suggestedQuality;
 

--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -494,7 +494,7 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
 /**
  * Convert a state value from the typed value to NSString.
  *
- * @param quality A |YTPlayerState| parameter.
+ * @param state A |YTPlayerState| parameter.
  * @return A string value to be used in the JavaScript bridge.
  */
 + (NSString *)stringForPlayerState:(YTPlayerState)state {
@@ -766,12 +766,13 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
  * Private method for cueing both cases of playlist ID and array of video IDs. Cueing
  * a playlist does not start playback.
  *
+ * Result: The result of cueing the playlist.
+ *
  * @param cueingString A JavaScript string representing an array, playlist ID or list of
  *                     video IDs to play with the playlist player.
  * @param index 0-index position of video to start playback on.
  * @param startSeconds Seconds after start of video to begin playback.
  * @param suggestedQuality Suggested YTPlaybackQuality to play the videos.
- * @return The result of cueing the playlist.
  */
 - (void)cuePlaylist:(NSString *)cueingString
                index:(int)index
@@ -789,12 +790,13 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
  * Private method for loading both cases of playlist ID and array of video IDs. Loading
  * a playlist automatically starts playback.
  *
+ * Result: The result of cueing the playlist.
+ *
  * @param cueingString A JavaScript string representing an array, playlist ID or list of
  *                     video IDs to play with the playlist player.
  * @param index 0-index position of video to start playback on.
  * @param startSeconds Seconds after start of video to begin playback.
  * @param suggestedQuality Suggested YTPlaybackQuality to play the videos.
- * @return The result of cueing the playlist.
  */
 - (void)loadPlaylist:(NSString *)cueingString
                index:(int)index


### PR DESCRIPTION
Removes Xcode warnings about documentation. In detail:

- Changes "quality" parameter for "suggestedQuality" in setPlaybackQuality:
- Changes "quality" parameter for "state" in stringForPlayerState:
- Changes the @return documentation for a "Result: ..." line in cuePlaylist:index:, since the method generates a result but doesn't return (declared void).
- Changes the @return documentation for a "Result: .." line in loadPlaylist:index:, since the method generates a result but doesn't return (declared void).