### PR TITLE
Fixing documentation warnings

### DIFF
--- a/Classes/YTPlayerView.h
+++ b/Classes/YTPlayerView.h
@@ -611,7 +611,7 @@ typedef NS_ENUM(NSInteger, YTPlayerError) {
  * |default|. This method corresponds to the JavaScript API defined here:
  *   https://developers.google.com/youtube/iframe_api_reference#setPlaybackQuality
  *
- * @param quality YTPlaybackQuality value to suggest for the player.
+ * @param suggestedQuality YTPlaybackQuality value to suggest for the player.
  */
 - (void)setPlaybackQuality:(YTPlaybackQuality)suggestedQuality;
 

--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -494,7 +494,7 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
 /**
  * Convert a state value from the typed value to NSString.
  *
- * @param quality A |YTPlayerState| parameter.
+ * @param state A |YTPlayerState| parameter.
  * @return A string value to be used in the JavaScript bridge.
  */
 + (NSString *)stringForPlayerState:(YTPlayerState)state {

--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -771,7 +771,6 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
  * @param index 0-index position of video to start playback on.
  * @param startSeconds Seconds after start of video to begin playback.
  * @param suggestedQuality Suggested YTPlaybackQuality to play the videos.
- * @return The result of cueing the playlist.
  */
 - (void)cuePlaylist:(NSString *)cueingString
                index:(int)index
@@ -794,7 +793,6 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
  * @param index 0-index position of video to start playback on.
  * @param startSeconds Seconds after start of video to begin playback.
  * @param suggestedQuality Suggested YTPlaybackQuality to play the videos.
- * @return The result of cueing the playlist.
  */
 - (void)loadPlaylist:(NSString *)cueingString
                index:(int)index


### PR DESCRIPTION
Using the helper in the latest Xcode 9.2 with SWIFT 4, a couple of documentation warnings appear. Being a developer with a no-warnings policy I thought I would try to remove there warnings.



Kind regards, 
Esben