### PR TITLE
Added extension to YTPlayerView for Mute and unMute Video.

### DIFF
--- a/youtube-ios-player-helper.xcodeproj/project.pbxproj
+++ b/youtube-ios-player-helper.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4E02070022184870008651F6 /* YTPlayerView+Mute_unMute.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E0206FE22184870008651F6 /* YTPlayerView+Mute_unMute.h */; };
+		4E02070122184870008651F6 /* YTPlayerView+Mute_unMute.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E0206FF22184870008651F6 /* YTPlayerView+Mute_unMute.m */; };
 		B3C76A271B975ADB00F375B4 /* YTPlayerView.h in Headers */ = {isa = PBXBuildFile; fileRef = B3C76A251B975ADB00F375B4 /* YTPlayerView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B3C76A281B975ADB00F375B4 /* YTPlayerView.m in Sources */ = {isa = PBXBuildFile; fileRef = B3C76A261B975ADB00F375B4 /* YTPlayerView.m */; };
 		B3C76A2F1B975C0100F375B4 /* YouTubeiOSPlayerHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = B3C76A2D1B975BD500F375B4 /* YouTubeiOSPlayerHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -14,6 +16,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		4E0206FE22184870008651F6 /* YTPlayerView+Mute_unMute.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "YTPlayerView+Mute_unMute.h"; sourceTree = "<group>"; };
+		4E0206FF22184870008651F6 /* YTPlayerView+Mute_unMute.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "YTPlayerView+Mute_unMute.m"; sourceTree = "<group>"; };
 		B3C76A1A1B975AA700F375B4 /* YouTubeiOSPlayerHelper.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = YouTubeiOSPlayerHelper.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3C76A1F1B975AA700F375B4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B3C76A251B975ADB00F375B4 /* YTPlayerView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = YTPlayerView.h; path = Classes/YTPlayerView.h; sourceTree = SOURCE_ROOT; };
@@ -57,6 +61,8 @@
 				B3C76A261B975ADB00F375B4 /* YTPlayerView.m */,
 				B3C76A1F1B975AA700F375B4 /* Info.plist */,
 				B3C76A2D1B975BD500F375B4 /* YouTubeiOSPlayerHelper.h */,
+				4E0206FE22184870008651F6 /* YTPlayerView+Mute_unMute.h */,
+				4E0206FF22184870008651F6 /* YTPlayerView+Mute_unMute.m */,
 			);
 			path = "youtube-ios-player-helper";
 			sourceTree = "<group>";
@@ -68,6 +74,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4E02070022184870008651F6 /* YTPlayerView+Mute_unMute.h in Headers */,
 				B3C76A271B975ADB00F375B4 /* YTPlayerView.h in Headers */,
 				B3C76A2F1B975C0100F375B4 /* YouTubeiOSPlayerHelper.h in Headers */,
 			);
@@ -142,6 +149,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B3C76A281B975ADB00F375B4 /* YTPlayerView.m in Sources */,
+				4E02070122184870008651F6 /* YTPlayerView+Mute_unMute.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/youtube-ios-player-helper/YTPlayerView+Mute_unMute.h
+++ b/youtube-ios-player-helper/YTPlayerView+Mute_unMute.h
@@ -1,0 +1,40 @@
+//
+//  YTPlayerView+Mute_unMute.h
+//  YouTubeiOSPlayerHelper
+//
+//  Created by Abhay Singh Naurang on 16/02/19.
+//  Copyright © 2019 YouTube Developer Relations. All rights reserved.
+//
+
+#import <YouTubeiOSPlayerHelper/YouTubeiOSPlayerHelper.h>
+
+NS_ASSUME_NONNULL_BEGIN
+/** These enums represent the state of the current video in the player. */
+typedef NS_ENUM(NSInteger, YTPlayerMuteState) {
+    kYTPlayerMuteStateUnMuted = 0,
+    kYTPlayerMuteStateMuted = 1,
+};
+
+@interface YTPlayerView (Mute_unMute)
+/**
+ * mute or resumes playback on the loaded video. Corresponds to this method from
+ * the JavaScript API:
+ *   https://developers.google.com/youtube/iframe_api_reference#mute
+ */
+- (void)muteVideo;
+
+/**
+ * unMute playback on a playing video. Corresponds to this method from
+ * the JavaScript API:
+ *   https://developers.google.com/youtube/iframe_api_reference#mute
+ */
+- (void)unMuteVideo;
+/**
+ * muteState playback on a playing video. Corresponds to this method from
+ * the JavaScript API:
+ *   https://developers.google.com/youtube/iframe_api_reference#mute
+ */
+- (BOOL)isMuted;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/youtube-ios-player-helper/YTPlayerView+Mute_unMute.m
+++ b/youtube-ios-player-helper/YTPlayerView+Mute_unMute.m
@@ -1,0 +1,47 @@
+//
+//  YTPlayerView+Mute_unMute.m
+//  YouTubeiOSPlayerHelper
+//
+//  Created by Abhay Singh Naurang on 16/02/19.
+//  Copyright © 2019 YouTube Developer Relations. All rights reserved.
+//
+
+#import "YTPlayerView+Mute_unMute.h"
+
+NSString static *const kYTPlayerMuteStateUnMutedCode = @"false";
+NSString static *const kYTPlayerMuteStateMutedCode = @"true";
+
+@implementation YTPlayerView (Mute_unMute)
+
+
+#pragma mark - Player methods
+
+-(void)muteVideo{
+    [self.webView stringByEvaluatingJavaScriptFromString:@"player.mute();"];
+}
+
+-(void)unMuteVideo{
+    [self.webView stringByEvaluatingJavaScriptFromString:@"player.unMute();"];
+}
+
+- (BOOL)isMuted {
+    NSString *returnValue = [self.webView stringByEvaluatingJavaScriptFromString:@"player.isMuted()"];
+    return [YTPlayerView playerPlayerMuteStateForString:returnValue];
+}
+
+/**
+ * Convert a state value from NSString to the typed enum value.
+ *
+ * @param stateString A string representing player mute state. Ex: "false", "true".
+ * @return An enum value representing the player mute state.
+ */
++ (YTPlayerMuteState)playerPlayerMuteStateForString:(NSString *)stateString {
+    YTPlayerMuteState state = kYTPlayerMuteStateUnMuted;
+    if ([stateString isEqualToString:kYTPlayerMuteStateUnMutedCode]) {
+        state = kYTPlayerMuteStateUnMuted;
+    } else if ([stateString isEqualToString:kYTPlayerMuteStateMutedCode]) {
+        state = kYTPlayerMuteStateMuted;
+    }
+    return state;
+}
+@end


### PR DESCRIPTION
 This is first time, I am contributing to gitHub project.
Added extension to YTPlayerView for Mute and unMute Video.
Because I was working with YTPlayerView and I wanted to mute and unMute Video for some feature in the iOS app. I was not able to find right way to do that so, I decided to add category for YTPlayerView for Mute , unMute and getState of Mute functionality . So, that I can easily call mute and unMute function on YTPlayerView object.

If you liked my work then please add that feature to the project.
Thank You
