### PR TITLE
Load bundle by identifier to let the framework be used properly in Swift with CocoaPods

### DIFF
--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -715,9 +715,9 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
   // in case of using Swift and embedded frameworks, resources included not in main bundle,
   // but in framework bundle
   if (!path) {
-      path = [[[self class] frameworkBundle] pathForResource:@"YTPlayerView-iframe-player"
-                                                     ofType:@"html"
-                                                inDirectory:@"Assets"];
+      path = [[[self class] assetsBundle] pathForResource:@"YTPlayerView-iframe-player"
+                                                   ofType:@"html"
+                                              inDirectory:@"Assets"];
   }
     
   NSString *embedHTMLTemplate =
@@ -871,15 +871,17 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
   self.webView = nil;
 }
 
-+ (NSBundle *)frameworkBundle {
-    static NSBundle* frameworkBundle = nil;
++ (NSBundle *)assetsBundle {
+    static NSBundle* assetsBundle = nil;
+    
     static dispatch_once_t predicate;
     dispatch_once(&predicate, ^{
-        NSString* mainBundlePath = [[NSBundle bundleForClass:[self class]] resourcePath];
-        NSString* frameworkBundlePath = [mainBundlePath stringByAppendingPathComponent:@"Assets.bundle"];
-        frameworkBundle = [NSBundle bundleWithPath:frameworkBundlePath];
+        NSBundle *frameworkBundle = [NSBundle bundleWithIdentifier:@"org.cocoapods.youtube-ios-player-helper"];
+        NSString *assetsBundlePath = [frameworkBundle pathForResource:@"Assets" ofType:@"bundle"];
+        assetsBundle = [NSBundle bundleWithPath:assetsBundlePath];
     });
-    return frameworkBundle;
+
+    return assetsBundle;
 }
 
 @end


### PR DESCRIPTION
This is a fix for https://github.com/youtube/youtube-ios-player-helper/issues/249.
