### PR TITLE
Fix Podfile of sample app

### DIFF
--- a/Project/youtube-player-ios-example/Podfile
+++ b/Project/youtube-player-ios-example/Podfile
@@ -12,8 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-pod "youtube-ios-player-helper", :path => "../../youtube-ios-player-helper.podspec"
+platform :ios, '11.0'
+inhibit_all_warnings!
+use_frameworks!
 
-target "youtube-player-ios-exampleTests", :exclusive => true do
+target "youtube-player-ios-example" do
+  pod "youtube-ios-player-helper", :path => "../../youtube-ios-player-helper.podspec"
+
+  target "youtube-player-ios-exampleTests" do
     pod "OCMock", "3.1.2"
+  end
 end

--- a/Project/youtube-player-ios-example/youtube-player-ios-example.xcodeproj/project.pbxproj
+++ b/Project/youtube-player-ios-example/youtube-player-ios-example.xcodeproj/project.pbxproj
@@ -59,7 +59,6 @@
 		4D69941B18E22EE10073680F /* PlaylistViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlaylistViewController.h; sourceTree = "<group>"; };
 		4D69941C18E22EE10073680F /* PlaylistViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PlaylistViewController.m; sourceTree = "<group>"; };
 		4D69942118E22F000073680F /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
-		5EDBAF28CE586F953081FFD5 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		614CB957CD094425884C83E1 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		97FE8C7A7A914485BBD9A3D4 /* libPods-youtube-player-ios-exampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-youtube-player-ios-exampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F1A73947F21B4AC48269A4E /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
@@ -243,6 +242,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -470,6 +470,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "youtube-player-ios-example/youtube-player-ios-example-Prefix.pch";
 				INFOPLIST_FILE = "youtube-player-ios-example/youtube-player-ios-example-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
@@ -485,6 +486,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "youtube-player-ios-example/youtube-player-ios-example-Prefix.pch";
 				INFOPLIST_FILE = "youtube-player-ios-example/youtube-player-ios-example-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;

--- a/Project/youtube-player-ios-example/youtube-player-ios-example/PlaylistViewController.h
+++ b/Project/youtube-player-ios-example/youtube-player-ios-example/PlaylistViewController.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "YTPlayerView.h"
+#import <youtube_ios_player_helper/YTPlayerView.h>
 
 @interface PlaylistViewController : UIViewController<YTPlayerViewDelegate>
 

--- a/Project/youtube-player-ios-example/youtube-player-ios-example/SingleVideoViewController.h
+++ b/Project/youtube-player-ios-example/youtube-player-ios-example/SingleVideoViewController.h
@@ -14,7 +14,7 @@
 
 #import <UIKit/UIKit.h>
 
-#import "YTPlayerView.h"
+#import <youtube_ios_player_helper/YTPlayerView.h>
 
 @interface SingleVideoViewController : UIViewController<YTPlayerViewDelegate>
 


### PR DESCRIPTION
Using Cocoapods 1.8.4 you couldn't build and run the sample app in the Project directory.