### PR TITLE
Set app BundleID as the baseURL for the webView

### DIFF
--- a/Classes/YTPlayerView.h
+++ b/Classes/YTPlayerView.h
@@ -23,7 +23,7 @@ typedef NS_ENUM(NSInteger, YTPlayerState) {
     kYTPlayerStatePlaying,
     kYTPlayerStatePaused,
     kYTPlayerStateBuffering,
-    kYTPlayerStateQueued,
+    kYTPlayerStateCued,
     kYTPlayerStateUnknown
 };
 

--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -486,7 +486,7 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
   } else if ([stateString isEqualToString:kYTPlayerStateBufferingCode]) {
     state = kYTPlayerStateBuffering;
   } else if ([stateString isEqualToString:kYTPlayerStateCuedCode]) {
-    state = kYTPlayerStateQueued;
+    state = kYTPlayerStateCued;
   }
   return state;
 }
@@ -509,7 +509,7 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
       return kYTPlayerStatePausedCode;
     case kYTPlayerStateBuffering:
       return kYTPlayerStateBufferingCode;
-    case kYTPlayerStateQueued:
+    case kYTPlayerStateCued:
       return kYTPlayerStateCuedCode;
     default:
       return kYTPlayerStateUnknownCode;
@@ -557,7 +557,7 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
       } else if ([data isEqual:kYTPlayerStateBufferingCode]) {
         state = kYTPlayerStateBuffering;
       } else if ([data isEqual:kYTPlayerStateCuedCode]) {
-        state = kYTPlayerStateQueued;
+        state = kYTPlayerStateCued;
       } else if ([data isEqual:kYTPlayerStateUnstartedCode]) {
         state = kYTPlayerStateUnstarted;
       }

--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -66,7 +66,7 @@ NSErrorDomain static const NoStringErrorDomain = @"NoStringErrorDomain";
 
 @interface YTPlayerView() <WKNavigationDelegate>
 
-@property (nonatomic, strong) NSURL *originURL;
+@property (nonatomic) NSURL *originURL;
 @property (nonatomic, weak) UIView *initialLoadingView;
 
 @end
@@ -642,6 +642,14 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
 
 #pragma mark - Private methods
 
+- (NSURL *)originURL {
+  if (!_originURL) {
+    NSString *bundleId = [[NSBundle mainBundle] bundleIdentifier];
+    _originURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://%@", bundleId]];
+  }
+  return _originURL;
+}
+
 /**
  * Private method to handle "navigation" to a callback URL of the format
  * ytplayer://action?data=someData
@@ -815,12 +823,6 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
   if ([playerParams objectForKey:@"playerVars"]) {
     NSMutableDictionary *playerVars = [[NSMutableDictionary alloc] init];
     [playerVars addEntriesFromDictionary:[playerParams objectForKey:@"playerVars"]];
-      
-    if (![playerVars objectForKey:@"origin"]) {
-        self.originURL = [NSURL URLWithString:@"about:blank"];
-    } else {
-        self.originURL = [NSURL URLWithString: [playerVars objectForKey:@"origin"]];
-    }
   } else {
     // This must not be empty so we can render a '{}' in the output JSON
     [playerParams setValue:[[NSDictionary alloc] init] forKey:@"playerVars"];

--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -62,7 +62,9 @@ NSString static *const kYTPlayerOAuthRegexPattern = @"^http(s)://accounts.google
 NSString static *const kYTPlayerStaticProxyRegexPattern = @"^https://content.googleapis.com/static/proxy.html(.*)$";
 NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googlesyndication.com/sodar/(.*).html$";
 
-@interface YTPlayerView()
+NSErrorDomain static const NoStringErrorDomain = @"NoStringErrorDomain";
+
+@interface YTPlayerView() <WKNavigationDelegate>
 
 @property (nonatomic, strong) NSURL *originURL;
 @property (nonatomic, weak) UIView *initialLoadingView;
@@ -123,7 +125,7 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
   [self stringFromEvaluatingJavaScript:command];
 }
 
-#pragma mark - Cueing methods
+#pragma mark - Queueing methods
 
 - (void)cueVideoById:(NSString *)videoId
         startSeconds:(float)startSeconds
@@ -211,7 +213,7 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
   [self stringFromEvaluatingJavaScript:command];
 }
 
-#pragma mark - Cueing methods for lists
+#pragma mark - Queueing methods for lists
 
 - (void)cuePlaylistByPlaylistId:(NSString *)playlistId
                           index:(int)index
@@ -257,9 +259,20 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
 
 #pragma mark - Setting the playback rate
 
-- (float)playbackRate {
-  NSString *returnValue = [self stringFromEvaluatingJavaScript:@"player.getPlaybackRate();"];
-  return [returnValue floatValue];
+- (void)playbackRate:(_Nullable jsFloatCompletionHandler)completionHandler {
+  [self stringFromEvaluatingJavaScript:@"player.getPlaybackRate();"
+                     completionHandler:^(NSString *_Nullable result, NSError *_Nullable error) {
+    if (!completionHandler) {
+      return;
+    }
+
+    if (error) {
+      completionHandler(-1, error);
+      return;
+    }
+
+    completionHandler([result floatValue], nil);
+  }];
 }
 
 - (void)setPlaybackRate:(float)suggestedRate {
@@ -267,20 +280,30 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
   [self stringFromEvaluatingJavaScript:command];
 }
 
-- (NSArray *)availablePlaybackRates {
-  NSString *returnValue =
-      [self stringFromEvaluatingJavaScript:@"player.getAvailablePlaybackRates();"];
+- (void)availablePlaybackRates:(_Nullable jsArrayCompletionHandler)completionHandler {
+  [self stringFromEvaluatingJavaScript:@"player.getAvailablePlaybackRates();"
+                     completionHandler:^(NSString *_Nullable result, NSError * _Nullable error) {
+    if (!completionHandler) {
+      return;
+    }
 
-  NSData *playbackRateData = [returnValue dataUsingEncoding:NSUTF8StringEncoding];
-  NSError *jsonDeserializationError;
-  NSArray *playbackRates = [NSJSONSerialization JSONObjectWithData:playbackRateData
-                                                           options:kNilOptions
-                                                             error:&jsonDeserializationError];
-  if (jsonDeserializationError) {
-    return nil;
-  }
+    if (error) {
+      completionHandler(nil, error);
+      return;
+    }
 
-  return playbackRates;
+    NSData *playbackRateData = [result dataUsingEncoding:NSUTF8StringEncoding];
+    NSError *jsonDeserializationError;
+    NSArray *playbackRates = [NSJSONSerialization JSONObjectWithData:playbackRateData
+                                                             options:kNilOptions
+                                                               error:&jsonDeserializationError];
+    if (jsonDeserializationError) {
+      completionHandler(nil, jsonDeserializationError);
+      return;
+    }
+
+    completionHandler(playbackRates, nil);
+  }];
 }
 
 #pragma mark - Setting playback behavior for playlists
@@ -299,23 +322,62 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
 
 #pragma mark - Playback status
 
-- (float)videoLoadedFraction {
-  return [[self stringFromEvaluatingJavaScript:@"player.getVideoLoadedFraction();"] floatValue];
+- (void)videoLoadedFraction:(_Nullable jsFloatCompletionHandler)completionHandler {
+  [self stringFromEvaluatingJavaScript:@"player.getVideoLoadedFraction();"
+                     completionHandler:^(NSString *_Nullable result, NSError *_Nullable error) {
+    if (!completionHandler) {
+      return;
+    }
+
+    if (error) {
+      completionHandler(-1, error);
+      return;
+    }
+
+    completionHandler([result floatValue], error);
+  }];
 }
 
-- (YTPlayerState)playerState {
-  NSString *returnValue = [self stringFromEvaluatingJavaScript:@"player.getPlayerState();"];
-  return [YTPlayerView playerStateForString:returnValue];
+- (void)playerState:(_Nullable jsPlayerStateCompletionHandler)completionHandler {
+  [self stringFromEvaluatingJavaScript:@"player.getPlayerState();"
+                     completionHandler:^(NSString *_Nullable result, NSError *_Nullable error) {
+    if (!completionHandler) {
+      return;
+    }
+    if (error) {
+      completionHandler(kYTPlayerStateUnknown, error);
+      return;
+    }
+    completionHandler([YTPlayerView playerStateForString:result], nil);
+  }];
 }
 
-- (float)currentTime {
-  return [[self stringFromEvaluatingJavaScript:@"player.getCurrentTime();"] floatValue];
+- (void)currentTime:(_Nullable jsFloatCompletionHandler)completionHandler {
+  [self stringFromEvaluatingJavaScript:@"player.getCurrentTime();"
+                     completionHandler:^(NSString *_Nullable result, NSError *_Nullable error) {
+    if (!completionHandler) {
+      return;
+    }
+    if (error) {
+      completionHandler(-1, error);
+      return;
+    }
+    completionHandler([result floatValue], nil);
+  }];
 }
 
-// Playback quality
-- (YTPlaybackQuality)playbackQuality {
-  NSString *qualityValue = [self stringFromEvaluatingJavaScript:@"player.getPlaybackQuality();"];
-  return [YTPlayerView playbackQualityForString:qualityValue];
+- (void)playbackQuality:(_Nullable jsPlaybackQualityCompletionHandler)completionHandler {
+  [self stringFromEvaluatingJavaScript:@"player.getPlaybackQuality();"
+                     completionHandler:^(NSString *_Nullable result, NSError *_Nullable error) {
+    if (!completionHandler) {
+      return;
+    }
+    if (error) {
+      completionHandler(kYTPlaybackQualityUnknown, error);
+      return;
+    }
+    completionHandler([YTPlayerView playbackQualityForString:result], nil);
+  }];
 }
 
 - (void)setPlaybackQuality:(YTPlaybackQuality)suggestedQuality {
@@ -324,40 +386,105 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
   [self stringFromEvaluatingJavaScript:command];
 }
 
+- (void)availableQualityLevels:(_Nullable jsArrayCompletionHandler)completionHandler {
+  [self stringFromEvaluatingJavaScript:@"player.getAvailableQualityLevels().toString();"
+                     completionHandler:^(NSString *_Nullable result, NSError *_Nullable error) {
+    if (!completionHandler) {
+      return;
+    }
+    if (error) {
+      completionHandler(nil, error);
+    }
+    NSArray *rawQualityValues = [result componentsSeparatedByString:@","];
+    NSMutableArray *levels = [[NSMutableArray alloc] init];
+    for (NSString *rawQualityValue in rawQualityValues) {
+      YTPlaybackQuality quality = [YTPlayerView playbackQualityForString:rawQualityValue];
+      [levels addObject:@(quality)];
+    }
+    completionHandler(levels, nil);
+  }];
+}
+
 #pragma mark - Video information methods
 
-- (NSTimeInterval)duration {
-  return [[self stringFromEvaluatingJavaScript:@"player.getDuration();"] doubleValue];
+- (void)duration:(_Nullable jsDoubleCompletionHandler)completionHandler {
+  [self stringFromEvaluatingJavaScript:@"player.getDuration();"
+                     completionHandler:^(NSString *_Nullable result, NSError *_Nullable error) {
+    if (!completionHandler) {
+      return;
+    }
+    if (error) {
+      completionHandler(-1, error);
+      return;
+    }
+    completionHandler([result doubleValue], nil);
+  }];
 }
 
-- (NSURL *)videoUrl {
-  return [NSURL URLWithString:[self stringFromEvaluatingJavaScript:@"player.getVideoUrl();"]];
+- (void)videoUrl:(_Nullable jsURLCompletionHandler)completionHandler {
+  [self stringFromEvaluatingJavaScript:@"player.getVideoUrl();"
+                     completionHandler:^(NSString *_Nullable result, NSError *_Nullable error) {
+    if (!completionHandler) {
+      return;
+    }
+    if (error) {
+      completionHandler(nil, error);
+      return;
+    }
+    completionHandler([NSURL URLWithString:result], nil);
+  }];
 }
 
-- (NSString *)videoEmbedCode {
-  return [self stringFromEvaluatingJavaScript:@"player.getVideoEmbedCode();"];
+- (void)videoEmbedCode:(_Nullable jsStringCompletionHandler)completionHandler {
+  [self stringFromEvaluatingJavaScript:@"player.getVideoEmbedCode();"
+                     completionHandler:^(NSString *_Nullable result, NSError *_Nullable error) {
+    if (!completionHandler) {
+      return;
+    }
+    if (error) {
+      completionHandler(nil, error);
+      return;
+    }
+    completionHandler(result, nil);
+  }];
 }
 
 #pragma mark - Playlist methods
 
-- (NSArray *)playlist {
-  NSString *returnValue = [self stringFromEvaluatingJavaScript:@"player.getPlaylist();"];
-
-  NSData *playlistData = [returnValue dataUsingEncoding:NSUTF8StringEncoding];
-  NSError *jsonDeserializationError;
-  NSArray *videoIds = [NSJSONSerialization JSONObjectWithData:playlistData
-                                                      options:kNilOptions
-                                                        error:&jsonDeserializationError];
-  if (jsonDeserializationError) {
-    return nil;
-  }
-
-  return videoIds;
+- (void)playlist:(_Nullable jsArrayCompletionHandler)completionHandler {
+  [self stringFromEvaluatingJavaScript:@"player.getPlaylist();"
+                     completionHandler:^(NSString *_Nullable result, NSError *_Nullable error) {
+    if (!completionHandler) {
+      return;
+    }
+    if (error) {
+      completionHandler(nil, error);
+    }
+    NSData *playlistData = [result dataUsingEncoding:NSUTF8StringEncoding];
+    NSError *jsonDeserializationError;
+    NSArray *videoIds = [NSJSONSerialization JSONObjectWithData:playlistData
+                                                        options:kNilOptions
+                                                          error:&jsonDeserializationError];
+    if (jsonDeserializationError) {
+      completionHandler(nil, jsonDeserializationError);
+      return;
+    }
+    completionHandler(videoIds, nil);
+  }];
 }
 
-- (int)playlistIndex {
-  NSString *returnValue = [self stringFromEvaluatingJavaScript:@"player.getPlaylistIndex();"];
-  return [returnValue intValue];
+- (void)playlistIndex:(_Nullable jsIntCompletionHandler)completionHandler {
+  [self stringFromEvaluatingJavaScript:@"player.getPlaylistIndex();"
+                     completionHandler:^(NSString *_Nullable result, NSError *_Nullable error) {
+    if (!completionHandler) {
+      return;
+    }
+    if (error) {
+      completionHandler(-1, error);
+      return;
+    }
+    completionHandler([result intValue], nil);
+  }];
 }
 
 #pragma mark - Playing a video in a playlist
@@ -377,40 +504,6 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
 }
 
 #pragma mark - Helper methods
-
-- (NSArray *)availableQualityLevels {
-  NSString *returnValue =
-      [self stringFromEvaluatingJavaScript:@"player.getAvailableQualityLevels().toString();"];
-  if(!returnValue) return nil;
-
-  NSArray *rawQualityValues = [returnValue componentsSeparatedByString:@","];
-  NSMutableArray *levels = [[NSMutableArray alloc] init];
-  for (NSString *rawQualityValue in rawQualityValues) {
-    YTPlaybackQuality quality = [YTPlayerView playbackQualityForString:rawQualityValue];
-    [levels addObject:[NSNumber numberWithInt:quality]];
-  }
-  return levels;
-}
-
-- (BOOL)webView:(UIWebView *)webView
-    shouldStartLoadWithRequest:(NSURLRequest *)request
-                navigationType:(UIWebViewNavigationType)navigationType {
-  if ([request.URL.host isEqual: self.originURL.host]) {
-    return YES;
-  } else if ([request.URL.scheme isEqual:@"ytplayer"]) {
-    [self notifyDelegateOfYouTubeCallbackUrl:request.URL];
-    return NO;
-  } else if ([request.URL.scheme isEqual: @"http"] || [request.URL.scheme isEqual:@"https"]) {
-    return [self handleHttpNavigationToUrl:request.URL];
-  }
-  return YES;
-}
-
-- (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error {
-  if (self.initialLoadingView) {
-    [self.initialLoadingView removeFromSuperview];
-  }
-}
 
 /**
  * Convert a quality value from NSString to the typed enum value.
@@ -516,17 +609,48 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
   }
 }
 
+#pragma mark - WKNavigationDelegate
+
+- (void)webView:(WKWebView *)webView
+decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction
+decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
+  NSURLRequest *request = navigationAction.request;
+  if ([request.URL.host isEqual: self.originURL.host]) {
+    decisionHandler(WKNavigationActionPolicyAllow);
+    return;
+  } else if ([request.URL.scheme isEqual:@"ytplayer"]) {
+    [self notifyDelegateOfYouTubeCallbackUrl:request.URL];
+    decisionHandler(WKNavigationActionPolicyCancel);
+    return;
+  } else if ([request.URL.scheme isEqual: @"http"] || [request.URL.scheme isEqual:@"https"]) {
+    if ([self handleHttpNavigationToUrl:request.URL]) {
+      decisionHandler(WKNavigationActionPolicyAllow);
+    } else {
+      decisionHandler(WKNavigationActionPolicyCancel);
+    }
+    return;
+  }
+  decisionHandler(WKNavigationActionPolicyAllow);
+}
+
+- (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation
+      withError:(NSError *)error {
+  if (self.initialLoadingView) {
+    [self.initialLoadingView removeFromSuperview];
+  }
+}
+
 #pragma mark - Private methods
 
 /**
  * Private method to handle "navigation" to a callback URL of the format
  * ytplayer://action?data=someData
- * This is how the UIWebView communicates with the containing Objective-C code.
+ * This is how the WKWebView communicates with the containing Objective-C code.
  * Side effects of this method are that it calls methods on this class's delegate.
  *
  * @param url A URL of the format ytplayer://action?data=value.
  */
-- (void)notifyDelegateOfYouTubeCallbackUrl: (NSURL *) url {
+- (void)notifyDelegateOfYouTubeCallbackUrl:(NSURL *) url {
   NSString *action = url.host;
 
   // We know the query can only be of the format ytplayer://action?data=SOMEVALUE,
@@ -602,7 +726,7 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
 - (BOOL)handleHttpNavigationToUrl:(NSURL *) url {
   // Usually this means the user has clicked on the YouTube logo or an error message in the
   // player. Most URLs should open in the browser. The only http(s) URL that should open in this
-  // UIWebView is the URL for the embed, which is of the format:
+  // WKWebView is the URL for the embed, which is of the format:
   //     http(s)://www.youtube.com/embed/[VIDEO ID]?[PARAMETERS]
   NSError *error = NULL;
   NSRegularExpression *ytRegex =
@@ -745,9 +869,7 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
 
   NSString *embedHTML = [NSString stringWithFormat:embedHTMLTemplate, playerVarsJsonString];
   [self.webView loadHTMLString:embedHTML baseURL: self.originURL];
-  [self.webView setDelegate:self];
-  self.webView.allowsInlineMediaPlayback = YES;
-  self.webView.mediaPlaybackRequiresUserAction = NO;
+  self.webView.navigationDelegate = self;
   
   if ([self.delegate respondsToSelector:@selector(playerViewPreferredInitialLoadingView:)]) {
     UIView *initialLoadingView = [self.delegate playerViewPreferredInitialLoadingView:self];
@@ -828,10 +950,41 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
  * Private method for evaluating JavaScript in the WebView.
  *
  * @param jsToExecute The JavaScript code in string format that we want to execute.
- * @return JavaScript response from evaluating code.
  */
-- (NSString *)stringFromEvaluatingJavaScript:(NSString *)jsToExecute {
-  return [self.webView stringByEvaluatingJavaScriptFromString:jsToExecute];
+- (void)stringFromEvaluatingJavaScript:(NSString *)jsToExecute {
+  [self stringFromEvaluatingJavaScript:jsToExecute completionHandler:nil];
+}
+
+/**
+ * Private method for evaluating JavaScript in the WebView.
+ *
+ * @param jsToExecute The JavaScript code in string format that we want to execute.
+ * @param completionHandler A block to invoke when script evaluation completes or fails.
+ */
+- (void)stringFromEvaluatingJavaScript:(NSString *)jsToExecute
+                     completionHandler:(_Nullable jsStringCompletionHandler)completionHandler {
+  [_webView evaluateJavaScript:jsToExecute
+             completionHandler:^(id _Nullable result, NSError *_Nullable error) {
+    if (!completionHandler) {
+      return;
+    }
+
+    if (error) {
+      completionHandler(nil, error);
+      return;
+    }
+    if (![result isKindOfClass:[NSString class]]) {
+      NSDictionary *errorUserInfo = @{
+        NSLocalizedDescriptionKey: @"The returned JS result is an unsupported object.",
+      };
+      NSError *error = [[NSError alloc] initWithDomain:NoStringErrorDomain code:100
+                                              userInfo:errorUserInfo];
+      completionHandler(nil, error);
+      return;
+    }
+
+    completionHandler((NSString *)result, nil);
+  }];
 }
 
 /**
@@ -846,24 +999,27 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
 
 #pragma mark - Exposed for Testing
 
-- (void)setWebView:(UIWebView *)webView {
+- (void)setWebView:(WKWebView *)webView {
   _webView = webView;
 }
 
-- (UIWebView *)createNewWebView {
-    UIWebView *webView = [[UIWebView alloc] initWithFrame:self.bounds];
-    webView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
-    webView.scrollView.scrollEnabled = NO;
-    webView.scrollView.bounces = NO;
-    
-    if ([self.delegate respondsToSelector:@selector(playerViewPreferredWebViewBackgroundColor:)]) {
-        webView.backgroundColor = [self.delegate playerViewPreferredWebViewBackgroundColor:self];
-        if (webView.backgroundColor == [UIColor clearColor]) {
-            webView.opaque = NO;
-        }
+- (WKWebView *)createNewWebView {
+  WKWebViewConfiguration *webViewConfiguration = [[WKWebViewConfiguration alloc] init];
+  webViewConfiguration.allowsInlineMediaPlayback = YES;
+  webViewConfiguration.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
+  WKWebView *webView = [[WKWebView alloc] initWithFrame:self.bounds
+                                          configuration:webViewConfiguration];
+  webView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
+  webView.scrollView.scrollEnabled = NO;
+  webView.scrollView.bounces = NO;
+
+  if ([self.delegate respondsToSelector:@selector(playerViewPreferredWebViewBackgroundColor:)]) {
+    webView.backgroundColor = [self.delegate playerViewPreferredWebViewBackgroundColor:self];
+    if (webView.backgroundColor == [UIColor clearColor]) {
+      webView.opaque = NO;
     }
-    
-    return webView;
+  }
+  return webView;
 }
 
 - (void)removeWebView {


### PR DESCRIPTION
**This PR should be merged after #362 . It is based on the changes applied there.**

Lazy load the originURL param and always set it to the current app bundleID. Prefix `@"http://"` to the URL if not the webView will not load.