### PR TITLE
Compare request.URL and originURL using lowercase Strings

### DIFF
--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -518,7 +518,10 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
 decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction
 decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
   NSURLRequest *request = navigationAction.request;
-  if ([request.URL.host isEqual: self.originURL.host]) {
+  // In case either the request or originURL are not lowercase we force them here.
+  // If we don't and we don't enter the first if statement the logic will try to open
+  // a browser.
+  if ([[request.URL.host lowercaseString] isEqualToString:[self.originURL.host lowercaseString]]) {
     decisionHandler(WKNavigationActionPolicyAllow);
     return;
   } else if ([request.URL.scheme isEqual:@"ytplayer"]) {
@@ -548,7 +551,8 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
 - (NSURL *)originURL {
   if (!_originURL) {
     NSString *bundleId = [[NSBundle mainBundle] bundleIdentifier];
-    _originURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://%@", bundleId]];
+    NSString *stringURL = [[NSString stringWithFormat:@"http://%@", bundleId] lowercaseString];
+    _originURL = [NSURL URLWithString:stringURL];
   }
   return _originURL;
 }


### PR DESCRIPTION
Otherwise if an app contains any Uppercasing in its name, we were encountering an issue in which request.URL.host and originURL.host were using different casing even tho the strings were the same and that was making the isEqual comparison fail.

Didn't encounter this issue before because the sample app we test against does not contain Uppercase in its name.

This fixes issue #374.