### PR TITLE
Prevents redirect of internal links

### DIFF
--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -686,7 +686,7 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
                                   options:0
                                     range:NSMakeRange(0, [url.absoluteString length])];
 
-  if (ytMatch || adMatch || oauthMatch || staticProxyMatch || syndicationMatch) {
+if (ytMatch || adMatch || oauthMatch || staticProxyMatch || syndicationMatch || [url.absoluteString.lowercaseString containsString:self.originURL.absoluteString.lowercaseString] ) {
     return YES;
   } else {
     [[UIApplication sharedApplication] openURL:url];


### PR DESCRIPTION
Webkit needs to open the url with the bundle identifier the current url doesn't match with the correct url