### PR TITLE
Add viewport meta tag

### DIFF
--- a/youtube-ios-player-helper/Assets.bundle/Assets/YTPlayerView-iframe-player.html
+++ b/youtube-ios-player-helper/Assets.bundle/Assets/YTPlayerView-iframe-player.html
@@ -16,6 +16,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <style>
     body { margin: 0; width:100%%; height:100%%;  background-color:#000000; }
     html { width:100%%; height:100%%; background-color:#000000; }


### PR DESCRIPTION
Reference screenshots:
[Before](https://ibb.co/hH9dmN8)
[After](https://ibb.co/hymvzhF)

If we define a viewport meta tag we can scale the player UI components to the desired size for the current device. In a webView if we don't specify it, the UI elements are very small.