### PR TITLE
iOS 9.0 support.

### DIFF
--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -679,9 +679,13 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
   if (ytMatch || adMatch || oauthMatch || staticProxyMatch || syndicationMatch) {
     return YES;
   } else {
-    [[UIApplication sharedApplication] openURL:url
-                                       options:@{UIApplicationOpenURLOptionUniversalLinksOnly: @NO}
-                             completionHandler:nil];
+    if (@available(iOS 10.0, *)) {
+      [[UIApplication sharedApplication] openURL:url
+                                         options:@{UIApplicationOpenURLOptionUniversalLinksOnly: @NO}
+                               completionHandler:nil];
+    } else {
+      [[UIApplication sharedApplication] openURL:url];
+    }
     return NO;
   }
 }
@@ -893,7 +897,11 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
 - (WKWebView *)createNewWebView {
   WKWebViewConfiguration *webViewConfiguration = [[WKWebViewConfiguration alloc] init];
   webViewConfiguration.allowsInlineMediaPlayback = YES;
-  webViewConfiguration.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
+  if (@available(iOS 10.0, *)) {
+    webViewConfiguration.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
+  } else {
+    webViewConfiguration.requiresUserActionForMediaPlayback = NO;
+  }
   WKWebView *webView = [[WKWebView alloc] initWithFrame:self.bounds
                                           configuration:webViewConfiguration];
   webView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);

--- a/youtube-ios-player-helper.podspec
+++ b/youtube-ios-player-helper.podspec
@@ -43,7 +43,7 @@ Pod::Spec.new do |s|
   s.social_media_url   = "https://twitter.com/YouTubeDev"
   s.source             = { :git => "https://github.com/youtube/youtube-ios-player-helper.git", :tag => "1.0.2" }
 
-  s.platform     = :ios, '10.0'
+  s.platform     = :ios, '9.0'
   s.requires_arc = true
 
   s.source_files = 'Classes'


### PR DESCRIPTION
Hi,

This lets apps supporting iOS 9.0 upgrade to 1.x series of this pod (WKWebView, etc).

I don't have an older device in front me of me to test but the new codepaths work as expected when forced to run on iOS 13.6.

Do you want this?