### PR TITLE
Fix bug where onPlayerError method was not called

### DIFF
--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -700,7 +700,7 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
         @"onReady" : @"onReady",
         @"onStateChange" : @"onStateChange",
         @"onPlaybackQualityChange" : @"onPlaybackQualityChange",
-        @"onError" : @"onPlayerError"
+        @"onError" : @"onError"
   };
   NSMutableDictionary *playerParams = [[NSMutableDictionary alloc] init];
   if (additionalPlayerParams) {

--- a/youtube-ios-player-helper/Assets.bundle/Assets/YTPlayerView-iframe-player.html
+++ b/youtube-ios-player-helper/Assets.bundle/Assets/YTPlayerView-iframe-player.html
@@ -76,7 +76,7 @@
         window.location.href = 'ytplayer://onPlaybackQualityChange?data=' + event.data;
     }
 
-    function onPlayerError(event) {
+    function onError(event) {
         if (event.data == 100) {
             error = true;
         }


### PR DESCRIPTION
Javascript method onPlayerError was not called, therefore, no errors are forwarded to the app. To get the player errors, we need to either change the initializer to map the events to the js methods or a rename of the current one. I opted for the second option.
[Reference](https://developers.google.com/youtube/iframe_api_reference)