### PR TITLE
Fix fullscreen toggle on iPadOS 15.4+

### DIFF
--- a/Sources/YTPlayerView.m
+++ b/Sources/YTPlayerView.m
@@ -907,6 +907,11 @@ createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration
   WKWebViewConfiguration *webViewConfiguration = [[WKWebViewConfiguration alloc] init];
   webViewConfiguration.allowsInlineMediaPlayback = YES;
   webViewConfiguration.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
+
+  if (@available(iOS 15.4, *)) {
+    webViewConfiguration.preferences.elementFullscreenEnabled = YES;
+  }
+
   WKWebView *webView = [[WKWebView alloc] initWithFrame:self.bounds
                                           configuration:webViewConfiguration];
   webView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);


### PR DESCRIPTION
Enable fullscreen in WKWebView configuration.

Fixes fullscreen toggle on iPadOS 15.4+ where this preference [elementFullscreenEnabled](https://developer.apple.com/documentation/webkit/wkpreferences/3917769-elementfullscreenenabled?language=objc) was introduced.

